### PR TITLE
Update Metric/Alert Descriptions and Release Statuses

### DIFF
--- a/DataLoader.json
+++ b/DataLoader.json
@@ -578,316 +578,6 @@
                 "releaseStatus": "preview"
             },
             {
-                "name": "equinix.fabric.metro.am_{metroCode}.latency",
-                "description": "Metro latency from AM to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.at_{metroCode}.latency",
-                "description": "Metro latency from AT to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.ba_{metroCode}.latency",
-                "description": "Metro latency from BA to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.bg_{metroCode}.latency",
-                "description": "Metro latency from BG to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.bl_{metroCode}.latency",
-                "description": "Metro latency from BL to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.bo_{metroCode}.latency",
-                "description": "Metro latency from BO to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.bx_{metroCode}.latency",
-                "description": "Metro latency from BX to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.ca_{metroCode}.latency",
-                "description": "Metro latency from CA to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.ch_{metroCode}.latency",
-                "description": "Metro latency from CH to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.cl_{metroCode}.latency",
-                "description": "Metro latency from CL to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.cu_{metroCode}.latency",
-                "description": "Metro latency from CU to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.da_{metroCode}.latency",
-                "description": "Metro latency from DA to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.db_{metroCode}.latency",
-                "description": "Metro latency from DB to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.dc_{metroCode}.latency",
-                "description": "Metro latency from DC to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.de_{metroCode}.latency",
-                "description": "Metro latency from DE to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.dx_{metroCode}.latency",
-                "description": "Metro latency from DX to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.fr_{metroCode}.latency",
-                "description": "Metro latency from FR to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.gv_{metroCode}.latency",
-                "description": "Metro latency from GV to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.he_{metroCode}.latency",
-                "description": "Metro latency from HE to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.hh_{metroCode}.latency",
-                "description": "Metro latency from HH to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.hk_{metroCode}.latency",
-                "description": "Metro latency from HK to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.ho_{metroCode}.latency",
-                "description": "Metro latency from HO to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.il_{metroCode}.latency",
-                "description": "Metro latency from IL to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.jh_{metroCode}.latency",
-                "description": "Metro latency from JH to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.ka_{metroCode}.latency",
-                "description": "Metro latency from KA to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.kl_{metroCode}.latency",
-                "description": "Metro latency from KL to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.la_{metroCode}.latency",
-                "description": "Metro latency from LA to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.ld_{metroCode}.latency",
-                "description": "Metro latency from LD to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.lm_{metroCode}.latency",
-                "description": "Metro latency from LM to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.ls_{metroCode}.latency",
-                "description": "Metro latency from LS to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.ma_{metroCode}.latency",
-                "description": "Metro latency from MA to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.mb_{metroCode}.latency",
-                "description": "Metro latency from MB to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.md_{metroCode}.latency",
-                "description": "Metro latency from MD to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.me_{metroCode}.latency",
-                "description": "Metro latency from ME to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.mi_{metroCode}.latency",
-                "description": "Metro latency from MI to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.ml_{metroCode}.latency",
-                "description": "Metro latency from ML to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.mo_{metroCode}.latency",
-                "description": "Metro latency from MO to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.mt_{metroCode}.latency",
-                "description": "Metro latency from MT to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.mu_{metroCode}.latency",
-                "description": "Metro latency from MU to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.mx_{metroCode}.latency",
-                "description": "Metro latency from MX to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.ny_{metroCode}.latency",
-                "description": "Metro latency from NY to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.os_{metroCode}.latency",
-                "description": "Metro latency from OS to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.ot_{metroCode}.latency",
-                "description": "Metro latency from OT to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.pa_{metroCode}.latency",
-                "description": "Metro latency from PA to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.pe_{metroCode}.latency",
-                "description": "Metro latency from PE to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.ph_{metroCode}.latency",
-                "description": "Metro latency from PH to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.rj_{metroCode}.latency",
-                "description": "Metro latency from RJ to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.se_{metroCode}.latency",
-                "description": "Metro latency from SE to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.sg_{metroCode}.latency",
-                "description": "Metro latency from SG to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.sk_{metroCode}.latency",
-                "description": "Metro latency from SK to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.sl_{metroCode}.latency",
-                "description": "Metro latency from SL to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.so_{metroCode}.latency",
-                "description": "Metro latency from SO to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.sp_{metroCode}.latency",
-                "description": "Metro latency from SP to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.st_{metroCode}.latency",
-                "description": "Metro latency from ST to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.sv_{metroCode}.latency",
-                "description": "Metro latency from SV to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.sy_{metroCode}.latency",
-                "description": "Metro latency from SY to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.tr_{metroCode}.latency",
-                "description": "Metro latency from TR to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.ty_{metroCode}.latency",
-                "description": "Metro latency from TY to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.va_{metroCode}.latency",
-                "description": "Metro latency from VA to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.wa_{metroCode}.latency",
-                "description": "Metro latency from WA to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.wi_{metroCode}.latency",
-                "description": "Metro latency from WI to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.zh_{metroCode}.latency",
-                "description": "Metro latency from ZH to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
                 "name": "equinix.fabric.route_aggregation.attribute.changed",
                 "description": "Route Aggregation named ${route_aggregation_name} attribute changed",
                 "releaseStatus": "preview"
@@ -941,622 +631,622 @@
             },
             {
                 "name": "equinix.fabric.metro.am_{metroCode}.latency",
-                "description": "Metro latency from AM to ${metroCode} in ms",
+                "description": "Amsterdam to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.am_{metroCode}.latency",
-                "description": "Metro latency from AM to ${metroCode} in ms",
+                "description": "Amsterdam to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.at_{metroCode}.latency",
-                "description": "Metro latency from AT to ${metroCode} in ms",
+                "description": "Atlanta to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.at_{metroCode}.latency",
-                "description": "Metro latency from AT to ${metroCode} in ms",
+                "description": "Atlanta to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ba_{metroCode}.latency",
-                "description": "Metro latency from BA to ${metroCode} in ms",
+                "description": "Barcelona to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ba_{metroCode}.latency",
-                "description": "Metro latency from BA to ${metroCode} in ms",
+                "description": "Barcelona to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.bg_{metroCode}.latency",
-                "description": "Metro latency from BG to ${metroCode} in ms",
+                "description": "Bogota to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.bg_{metroCode}.latency",
-                "description": "Metro latency from BG to ${metroCode} in ms",
+                "description": "Bogota to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.bl_{metroCode}.latency",
-                "description": "Metro latency from BL to ${metroCode} in ms",
+                "description": "Brussels to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.bl_{metroCode}.latency",
-                "description": "Metro latency from BL to ${metroCode} in ms",
+                "description": "Brussels to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.bo_{metroCode}.latency",
-                "description": "Metro latency from BO to ${metroCode} in ms",
+                "description": "Boston to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.bo_{metroCode}.latency",
-                "description": "Metro latency from BO to ${metroCode} in ms",
+                "description": "Boston to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.bx_{metroCode}.latency",
-                "description": "Metro latency from BX to ${metroCode} in ms",
+                "description": "Bordeaux to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.bx_{metroCode}.latency",
-                "description": "Metro latency from BX to ${metroCode} in ms",
+                "description": "Bordeaux to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ca_{metroCode}.latency",
-                "description": "Metro latency from CA to ${metroCode} in ms",
+                "description": "Canberra to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ca_{metroCode}.latency",
-                "description": "Metro latency from CA to ${metroCode} in ms",
+                "description": "Canberra to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ch_{metroCode}.latency",
-                "description": "Metro latency from CH to ${metroCode} in ms",
+                "description": "Chicago to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ch_{metroCode}.latency",
-                "description": "Metro latency from CH to ${metroCode} in ms",
+                "description": "Chicago to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.cl_{metroCode}.latency",
-                "description": "Metro latency from CL to ${metroCode} in ms",
+                "description": "Calgary to  ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.cl_{metroCode}.latency",
-                "description": "Metro latency from CL to ${metroCode} in ms",
+                "description": "Calgary to  ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.cu_{metroCode}.latency",
-                "description": "Metro latency from CU to ${metroCode} in ms",
+                "description": "Culpeper to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.cu_{metroCode}.latency",
-                "description": "Metro latency from CU to ${metroCode} in ms",
+                "description": "Culpeper to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.da_{metroCode}.latency",
-                "description": "Metro latency from DA to ${metroCode} in ms",
+                "description": "Dallas to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.da_{metroCode}.latency",
-                "description": "Metro latency from DA to ${metroCode} in ms",
+                "description": "Dallas to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.db_{metroCode}.latency",
-                "description": "Metro latency from DB to ${metroCode} in ms",
+                "description": "Dublin to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.db_{metroCode}.latency",
-                "description": "Metro latency from DB to ${metroCode} in ms",
+                "description": "Dublin to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.dc_{metroCode}.latency",
-                "description": "Metro latency from DC to ${metroCode} in ms",
+                "description": "Ashburn to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.dc_{metroCode}.latency",
-                "description": "Metro latency from DC to ${metroCode} in ms",
+                "description": "Ashburn to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.de_{metroCode}.latency",
-                "description": "Metro latency from DE to ${metroCode} in ms",
+                "description": "Denver to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.de_{metroCode}.latency",
-                "description": "Metro latency from DE to ${metroCode} in ms",
+                "description": "Denver to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.dx_{metroCode}.latency",
-                "description": "Metro latency from DX to ${metroCode} in ms",
+                "description": "Dubai to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.dx_{metroCode}.latency",
-                "description": "Metro latency from DX to ${metroCode} in ms",
+                "description": "Dubai to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.fr_{metroCode}.latency",
-                "description": "Metro latency from FR to ${metroCode} in ms",
+                "description": "Frankfurt to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.fr_{metroCode}.latency",
-                "description": "Metro latency from FR to ${metroCode} in ms",
+                "description": "Frankfurt to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.gv_{metroCode}.latency",
-                "description": "Metro latency from GV to ${metroCode} in ms",
+                "description": "Geneva to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.gv_{metroCode}.latency",
-                "description": "Metro latency from GV to ${metroCode} in ms",
+                "description": "Geneva to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.he_{metroCode}.latency",
-                "description": "Metro latency from HE to ${metroCode} in ms",
+                "description": "Helsinki to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.he_{metroCode}.latency",
-                "description": "Metro latency from HE to ${metroCode} in ms",
+                "description": "Helsinki to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.hh_{metroCode}.latency",
-                "description": "Metro latency from HH to ${metroCode} in ms",
+                "description": "Hamburg to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.hh_{metroCode}.latency",
-                "description": "Metro latency from HH to ${metroCode} in ms",
+                "description": "Hamburg to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.hk_{metroCode}.latency",
-                "description": "Metro latency from HK to ${metroCode} in ms",
+                "description": "Hong Kong to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.hk_{metroCode}.latency",
-                "description": "Metro latency from HK to ${metroCode} in ms",
+                "description": "Hong Kong to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ho_{metroCode}.latency",
-                "description": "Metro latency from HO to ${metroCode} in ms",
+                "description": "Houston to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ho_{metroCode}.latency",
-                "description": "Metro latency from HO to ${metroCode} in ms",
+                "description": "Houston to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.il_{metroCode}.latency",
-                "description": "Metro latency from IL to ${metroCode} in ms",
+                "description": "Istanbul to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.il_{metroCode}.latency",
-                "description": "Metro latency from IL to ${metroCode} in ms",
+                "description": "Istanbul to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.jh_{metroCode}.latency",
-                "description": "Metro latency from JH to ${metroCode} in ms",
+                "description": "Johor to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.jh_{metroCode}.latency",
-                "description": "Metro latency from JH to ${metroCode} in ms",
+                "description": "Johor to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ka_{metroCode}.latency",
-                "description": "Metro latency from KA to ${metroCode} in ms",
+                "description": "Kamloops to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ka_{metroCode}.latency",
-                "description": "Metro latency from KA to ${metroCode} in ms",
+                "description": "Kamloops to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.kl_{metroCode}.latency",
-                "description": "Metro latency from KL to ${metroCode} in ms",
+                "description": "Kuala Lumpur to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.kl_{metroCode}.latency",
-                "description": "Metro latency from KL to ${metroCode} in ms",
+                "description": "Kuala Lumpur to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.la_{metroCode}.latency",
-                "description": "Metro latency from LA to ${metroCode} in ms",
+                "description": "Los Angeles to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.la_{metroCode}.latency",
-                "description": "Metro latency from LA to ${metroCode} in ms",
+                "description": "Los Angeles to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ld_{metroCode}.latency",
-                "description": "Metro latency from LD to ${metroCode} in ms",
+                "description": "London to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ld_{metroCode}.latency",
-                "description": "Metro latency from LD to ${metroCode} in ms",
+                "description": "London to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.lm_{metroCode}.latency",
-                "description": "Metro latency from LM to ${metroCode} in ms",
+                "description": "Lima to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.lm_{metroCode}.latency",
-                "description": "Metro latency from LM to ${metroCode} in ms",
+                "description": "Lima to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ls_{metroCode}.latency",
-                "description": "Metro latency from LS to ${metroCode} in ms",
+                "description": "Lisbon to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ls_{metroCode}.latency",
-                "description": "Metro latency from LS to ${metroCode} in ms",
+                "description": "Lisbon to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ma_{metroCode}.latency",
-                "description": "Metro latency from MA to ${metroCode} in ms",
+                "description": "Manchester to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ma_{metroCode}.latency",
-                "description": "Metro latency from MA to ${metroCode} in ms",
+                "description": "Manchester to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.mb_{metroCode}.latency",
-                "description": "Metro latency from MB to ${metroCode} in ms",
+                "description": "Mumbai to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.mb_{metroCode}.latency",
-                "description": "Metro latency from MB to ${metroCode} in ms",
+                "description": "Mumbai to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.md_{metroCode}.latency",
-                "description": "Metro latency from MD to ${metroCode} in ms",
+                "description": "Madrid to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.md_{metroCode}.latency",
-                "description": "Metro latency from MD to ${metroCode} in ms",
+                "description": "Madrid to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.me_{metroCode}.latency",
-                "description": "Metro latency from ME to ${metroCode} in ms",
+                "description": "Melbourne to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.me_{metroCode}.latency",
-                "description": "Metro latency from ME to ${metroCode} in ms",
+                "description": "Melbourne to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.mi_{metroCode}.latency",
-                "description": "Metro latency from MI to ${metroCode} in ms",
+                "description": "Miami to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.mi_{metroCode}.latency",
-                "description": "Metro latency from MI to ${metroCode} in ms",
+                "description": "Miami to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ml_{metroCode}.latency",
-                "description": "Metro latency from ML to ${metroCode} in ms",
+                "description": "Milan to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ml_{metroCode}.latency",
-                "description": "Metro latency from ML to ${metroCode} in ms",
+                "description": "Milan to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.mo_{metroCode}.latency",
-                "description": "Metro latency from MO to ${metroCode} in ms",
+                "description": "Monterrey to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.mo_{metroCode}.latency",
-                "description": "Metro latency from MO to ${metroCode} in ms",
+                "description": "Monterrey to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.mt_{metroCode}.latency",
-                "description": "Metro latency from MT to ${metroCode} in ms",
+                "description": "Montreal to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.mt_{metroCode}.latency",
-                "description": "Metro latency from MT to ${metroCode} in ms",
+                "description": "Montreal to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.mu_{metroCode}.latency",
-                "description": "Metro latency from MU to ${metroCode} in ms",
+                "description": "Munich to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.mu_{metroCode}.latency",
-                "description": "Metro latency from MU to ${metroCode} in ms",
+                "description": "Munich to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.mx_{metroCode}.latency",
-                "description": "Metro latency from MX to ${metroCode} in ms",
+                "description": "Mexico City to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.mx_{metroCode}.latency",
-                "description": "Metro latency from MX to ${metroCode} in ms",
+                "description": "Mexico City to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ny_{metroCode}.latency",
-                "description": "Metro latency from NY to ${metroCode} in ms",
+                "description": "New York to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ny_{metroCode}.latency",
-                "description": "Metro latency from NY to ${metroCode} in ms",
+                "description": "New York to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.os_{metroCode}.latency",
-                "description": "Metro latency from OS to ${metroCode} in ms",
+                "description": "Osaka to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.os_{metroCode}.latency",
-                "description": "Metro latency from OS to ${metroCode} in ms",
+                "description": "Osaka to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ot_{metroCode}.latency",
-                "description": "Metro latency from OT to ${metroCode} in ms",
+                "description": "Ottawa to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ot_{metroCode}.latency",
-                "description": "Metro latency from OT to ${metroCode} in ms",
+                "description": "Ottawa to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.pa_{metroCode}.latency",
-                "description": "Metro latency from PA to ${metroCode} in ms",
+                "description": "Paris to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.pa_{metroCode}.latency",
-                "description": "Metro latency from PA to ${metroCode} in ms",
+                "description": "Paris to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.pe_{metroCode}.latency",
-                "description": "Metro latency from PE to ${metroCode} in ms",
+                "description": "Perth to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.pe_{metroCode}.latency",
-                "description": "Metro latency from PE to ${metroCode} in ms",
+                "description": "Perth to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ph_{metroCode}.latency",
-                "description": "Metro latency from PH to ${metroCode} in ms",
+                "description": "Philadelphia to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ph_{metroCode}.latency",
-                "description": "Metro latency from PH to ${metroCode} in ms",
+                "description": "Philadelphia to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.rj_{metroCode}.latency",
-                "description": "Metro latency from RJ to ${metroCode} in ms",
+                "description": "Rio de Janeiro to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.rj_{metroCode}.latency",
-                "description": "Metro latency from RJ to ${metroCode} in ms",
+                "description": "Rio de Janeiro to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.se_{metroCode}.latency",
-                "description": "Metro latency from SE to ${metroCode} in ms",
+                "description": "Seattle to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.se_{metroCode}.latency",
-                "description": "Metro latency from SE to ${metroCode} in ms",
+                "description": "Seattle to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.sg_{metroCode}.latency",
-                "description": "Metro latency from SG to ${metroCode} in ms",
+                "description": "Singapore to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.sg_{metroCode}.latency",
-                "description": "Metro latency from SG to ${metroCode} in ms",
+                "description": "Singapore to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.sk_{metroCode}.latency",
-                "description": "Metro latency from SK to ${metroCode} in ms",
+                "description": "Stockholm to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.sk_{metroCode}.latency",
-                "description": "Metro latency from SK to ${metroCode} in ms",
+                "description": "Stockholm to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.sl_{metroCode}.latency",
-                "description": "Metro latency from SL to ${metroCode} in ms",
+                "description": "Seoul to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.sl_{metroCode}.latency",
-                "description": "Metro latency from SL to ${metroCode} in ms",
+                "description": "Seoul to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.so_{metroCode}.latency",
-                "description": "Metro latency from SO to ${metroCode} in ms",
+                "description": "Sofia to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.so_{metroCode}.latency",
-                "description": "Metro latency from SO to ${metroCode} in ms",
+                "description": "Sofia to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.sp_{metroCode}.latency",
-                "description": "Metro latency from SP to ${metroCode} in ms",
+                "description": "Sao Paulo to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.sp_{metroCode}.latency",
-                "description": "Metro latency from SP to ${metroCode} in ms",
+                "description": "Sao Paulo to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.st_{metroCode}.latency",
-                "description": "Metro latency from ST to ${metroCode} in ms",
+                "description": "Santiago to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.st_{metroCode}.latency",
-                "description": "Metro latency from ST to ${metroCode} in ms",
+                "description": "Santiago to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.sv_{metroCode}.latency",
-                "description": "Metro latency from SV to ${metroCode} in ms",
+                "description": "Silicon Valley to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.sv_{metroCode}.latency",
-                "description": "Metro latency from SV to ${metroCode} in ms",
+                "description": "Silicon Valley to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.sy_{metroCode}.latency",
-                "description": "Metro latency from SY to ${metroCode} in ms",
+                "description": "Sydney to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.sy_{metroCode}.latency",
-                "description": "Metro latency from SY to ${metroCode} in ms",
+                "description": "Sydney to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.tr_{metroCode}.latency",
-                "description": "Metro latency from TR to ${metroCode} in ms",
+                "description": "Toronto to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.tr_{metroCode}.latency",
-                "description": "Metro latency from TR to ${metroCode} in ms",
+                "description": "Toronto to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ty_{metroCode}.latency",
-                "description": "Metro latency from TY to ${metroCode} in ms",
+                "description": "Tokyo to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ty_{metroCode}.latency",
-                "description": "Metro latency from TY to ${metroCode} in ms",
+                "description": "Tokyo to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.va_{metroCode}.latency",
-                "description": "Metro latency from VA to ${metroCode} in ms",
+                "description": "Vancouver to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.va_{metroCode}.latency",
-                "description": "Metro latency from VA to ${metroCode} in ms",
+                "description": "Vancouver to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.wa_{metroCode}.latency",
-                "description": "Metro latency from WA to ${metroCode} in ms",
+                "description": "Warsaw to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.wa_{metroCode}.latency",
-                "description": "Metro latency from WA to ${metroCode} in ms",
+                "description": "Warsaw to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.wi_{metroCode}.latency",
-                "description": "Metro latency from WI to ${metroCode} in ms",
+                "description": "Winnipeg to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.wi_{metroCode}.latency",
-                "description": "Metro latency from WI to ${metroCode} in ms",
+                "description": "Winnipeg to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.zh_{metroCode}.latency",
-                "description": "Metro latency from ZH to ${metroCode} in ms",
+                "description": "Zurich to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.zh_{metroCode}.latency",
-                "description": "Metro latency from ZH to ${metroCode} in ms",
+                "description": "Zurich to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1592,6 +1282,16 @@
         ],
         "alertNames": [
             {
+                "name": "equinix.fabric.connection.bandwidth_rx.usage",
+                "description": "Connection inbound bandwidth usage above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.connection.bandwidth_tx.usage",
+                "description": "Connection outbound bandwidth usage above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
                 "name": "equinix.fabric.connection.installed_routes_ipv4.utilization",
                 "description": "Utilization of connection '${connection_name}' active IPv4 routes reached ${threshold}",
                 "releaseStatus": "released"
@@ -1623,312 +1323,342 @@
             },
             {
                 "name": "equinix.fabric.metro.am_{metroCode}.latency",
-                "description": "Metro latency from AM to ${metroCode} in ms",
+                "description": "Metro latency from Amsterdam to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.at_{metroCode}.latency",
-                "description": "Metro latency from AT to ${metroCode} in ms",
+                "description": "Metro latency from Atlanta to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ba_{metroCode}.latency",
-                "description": "Metro latency from BA to ${metroCode} in ms",
+                "description": "Metro latency from Barcelona to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.bg_{metroCode}.latency",
-                "description": "Metro latency from BG to ${metroCode} in ms",
+                "description": "Metro latency from Bogota to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.bl_{metroCode}.latency",
-                "description": "Metro latency from BL to ${metroCode} in ms",
+                "description": "Metro latency from Brussels to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.bo_{metroCode}.latency",
-                "description": "Metro latency from BO to ${metroCode} in ms",
+                "description": "Metro latency from Boston to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.bx_{metroCode}.latency",
-                "description": "Metro latency from BX to ${metroCode} in ms",
+                "description": "Metro latency from Bordeaux to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ca_{metroCode}.latency",
-                "description": "Metro latency from CA to ${metroCode} in ms",
+                "description": "Metro latency from Canberra to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ch_{metroCode}.latency",
-                "description": "Metro latency from CH to ${metroCode} in ms",
+                "description": "Metro latency from Chicago to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.cl_{metroCode}.latency",
-                "description": "Metro latency from CL to ${metroCode} in ms",
+                "description": "Metro latency from Calgary to  ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.cu_{metroCode}.latency",
-                "description": "Metro latency from CU to ${metroCode} in ms",
+                "description": "Metro latency from Culpeper to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.da_{metroCode}.latency",
-                "description": "Metro latency from DA to ${metroCode} in ms",
+                "description": "Metro latency from Dallas to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.db_{metroCode}.latency",
-                "description": "Metro latency from DB to ${metroCode} in ms",
+                "description": "Metro latency from Dublin to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.dc_{metroCode}.latency",
-                "description": "Metro latency from DC to ${metroCode} in ms",
+                "description": "Metro latency from Ashburn to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.de_{metroCode}.latency",
-                "description": "Metro latency from DE to ${metroCode} in ms",
+                "description": "Metro latency from Denver to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.dx_{metroCode}.latency",
-                "description": "Metro latency from DX to ${metroCode} in ms",
+                "description": "Metro latency from Dubai to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.fr_{metroCode}.latency",
-                "description": "Metro latency from FR to ${metroCode} in ms",
+                "description": "Metro latency from Frankfurt to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.gv_{metroCode}.latency",
-                "description": "Metro latency from GV to ${metroCode} in ms",
+                "description": "Metro latency from Geneva to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.he_{metroCode}.latency",
-                "description": "Metro latency from HE to ${metroCode} in ms",
+                "description": "Metro latency from Helsinki to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.hh_{metroCode}.latency",
-                "description": "Metro latency from HH to ${metroCode} in ms",
+                "description": "Metro latency from Hamburg to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.hk_{metroCode}.latency",
-                "description": "Metro latency from HK to ${metroCode} in ms",
+                "description": "Metro latency from Hong Kong to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ho_{metroCode}.latency",
-                "description": "Metro latency from HO to ${metroCode} in ms",
+                "description": "Metro latency from Houston to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.il_{metroCode}.latency",
-                "description": "Metro latency from IL to ${metroCode} in ms",
+                "description": "Metro latency from Istanbul to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.jh_{metroCode}.latency",
-                "description": "Metro latency from JH to ${metroCode} in ms",
+                "description": "Metro latency from Johor to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ka_{metroCode}.latency",
-                "description": "Metro latency from KA to ${metroCode} in ms",
+                "description": "Metro latency from Kamloops to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.kl_{metroCode}.latency",
-                "description": "Metro latency from KL to ${metroCode} in ms",
+                "description": "Metro latency from Kuala Lumpur to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.la_{metroCode}.latency",
-                "description": "Metro latency from LA to ${metroCode} in ms",
+                "description": "Metro latency from Los Angeles to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ld_{metroCode}.latency",
-                "description": "Metro latency from LD to ${metroCode} in ms",
+                "description": "Metro latency from London to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.lm_{metroCode}.latency",
-                "description": "Metro latency from LM to ${metroCode} in ms",
+                "description": "Metro latency from Lima to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ls_{metroCode}.latency",
-                "description": "Metro latency from LS to ${metroCode} in ms",
+                "description": "Metro latency from Lisbon to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ma_{metroCode}.latency",
-                "description": "Metro latency from MA to ${metroCode} in ms",
+                "description": "Metro latency from Manchester to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.mb_{metroCode}.latency",
-                "description": "Metro latency from MB to ${metroCode} in ms",
+                "description": "Metro latency from Mumbai to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.md_{metroCode}.latency",
-                "description": "Metro latency from MD to ${metroCode} in ms",
+                "description": "Metro latency from Madrid to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.me_{metroCode}.latency",
-                "description": "Metro latency from ME to ${metroCode} in ms",
+                "description": "Metro latency from Melbourne to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.mi_{metroCode}.latency",
-                "description": "Metro latency from MI to ${metroCode} in ms",
+                "description": "Metro latency from Miami to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ml_{metroCode}.latency",
-                "description": "Metro latency from ML to ${metroCode} in ms",
+                "description": "Metro latency from Milan to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.mo_{metroCode}.latency",
-                "description": "Metro latency from MO to ${metroCode} in ms",
+                "description": "Metro latency from Monterrey to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.mt_{metroCode}.latency",
-                "description": "Metro latency from MT to ${metroCode} in ms",
+                "description": "Metro latency from Montreal to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.mu_{metroCode}.latency",
-                "description": "Metro latency from MU to ${metroCode} in ms",
+                "description": "Metro latency from Munich to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.mx_{metroCode}.latency",
-                "description": "Metro latency from MX to ${metroCode} in ms",
+                "description": "Metro latency from Mexico City to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ny_{metroCode}.latency",
-                "description": "Metro latency from NY to ${metroCode} in ms",
+                "description": "Metro latency from New York to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.os_{metroCode}.latency",
-                "description": "Metro latency from OS to ${metroCode} in ms",
+                "description": "Metro latency from Osaka to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ot_{metroCode}.latency",
-                "description": "Metro latency from OT to ${metroCode} in ms",
+                "description": "Metro latency from Ottawa to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.pa_{metroCode}.latency",
-                "description": "Metro latency from PA to ${metroCode} in ms",
+                "description": "Metro latency from Paris to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.pe_{metroCode}.latency",
-                "description": "Metro latency from PE to ${metroCode} in ms",
+                "description": "Metro latency from Perth to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ph_{metroCode}.latency",
-                "description": "Metro latency from PH to ${metroCode} in ms",
+                "description": "Metro latency from Philadelphia to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.rj_{metroCode}.latency",
-                "description": "Metro latency from RJ to ${metroCode} in ms",
+                "description": "Metro latency from Rio de Janeiro to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.se_{metroCode}.latency",
-                "description": "Metro latency from SE to ${metroCode} in ms",
+                "description": "Metro latency from Seattle to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.sg_{metroCode}.latency",
-                "description": "Metro latency from SG to ${metroCode} in ms",
+                "description": "Metro latency from Singapore to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.sk_{metroCode}.latency",
-                "description": "Metro latency from SK to ${metroCode} in ms",
+                "description": "Metro latency from Stockholm to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.sl_{metroCode}.latency",
-                "description": "Metro latency from SL to ${metroCode} in ms",
+                "description": "Metro latency from Seoul to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.so_{metroCode}.latency",
-                "description": "Metro latency from SO to ${metroCode} in ms",
+                "description": "Metro latency from Sofia to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.sp_{metroCode}.latency",
-                "description": "Metro latency from SP to ${metroCode} in ms",
+                "description": "Metro latency from Sao Paulo to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.st_{metroCode}.latency",
-                "description": "Metro latency from ST to ${metroCode} in ms",
+                "description": "Metro latency from Santiago to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.sv_{metroCode}.latency",
-                "description": "Metro latency from SV to ${metroCode} in ms",
+                "description": "Metro latency from Silicon Valley to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.sy_{metroCode}.latency",
-                "description": "Metro latency from SY to ${metroCode} in ms",
+                "description": "Metro latency from Sydney to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.tr_{metroCode}.latency",
-                "description": "Metro latency from TR to ${metroCode} in ms",
+                "description": "Metro latency from Toronto to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ty_{metroCode}.latency",
-                "description": "Metro latency from TY to ${metroCode} in ms",
+                "description": "Metro latency from Tokyo to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.va_{metroCode}.latency",
-                "description": "Metro latency from VA to ${metroCode} in ms",
+                "description": "Metro latency from Vancouver to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.wa_{metroCode}.latency",
-                "description": "Metro latency from WA to ${metroCode} in ms",
+                "description": "Metro latency from Warsaw to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.wi_{metroCode}.latency",
-                "description": "Metro latency from WI to ${metroCode} in ms",
+                "description": "Metro latency from Winnipeg to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.zh_{metroCode}.latency",
-                "description": "Metro latency from ZH to ${metroCode} in ms",
+                "description": "Metro latency from Zurich to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.port.bandwidth_rx.usage",
+                "description": "Port inbound bandwidth usage above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.port.bandwidth_tx.usage",
+                "description": "Port outbound bandwidth usage above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.port.packets_dropped_rx.count",
+                "description": "Port inbound dropped packets count above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.port.packets_dropped_tx.count",
+                "description": "Port outbound dropped packets count above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.port.packets_erred_rx.count",
+                "description": "Port inbound erred packets count above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.port.packets_erred_tx.count",
+                "description": "Port outbound erred packets count above ${threshold}",
                 "releaseStatus": "released"
             },
             {
@@ -1942,43 +1672,313 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.connection.bandwidth_rx.usage",
-                "description": "Connection inbound bandwidth usage above ${threshold}",
+                "name": "equinix.fabric.metro.am_{metroCode}.latency",
+                "description": "Metro latency from Amsterdam to ${metroCode} above ${threshold}",
                 "releaseStatus": "preview"
             },
             {
-                "name": "equinix.fabric.connection.bandwidth_tx.usage",
-                "description": "Connection outbound bandwidth usage above ${threshold}",
+                "name": "equinix.fabric.metro.at_{metroCode}.latency",
+                "description": "Metro latency from Atlanta to ${metroCode} above ${threshold}",
                 "releaseStatus": "preview"
             },
             {
-                "name": "equinix.fabric.port.bandwidth_rx.usage",
-                "description": "Port inbound bandwidth usage above ${threshold}",
+                "name": "equinix.fabric.metro.ba_{metroCode}.latency",
+                "description": "Metro latency from Barcelona to ${metroCode} above ${threshold}",
                 "releaseStatus": "preview"
             },
             {
-                "name": "equinix.fabric.port.bandwidth_tx.usage",
-                "description": "Port outbound bandwidth usage above ${threshold}",
+                "name": "equinix.fabric.metro.bg_{metroCode}.latency",
+                "description": "Metro latency from Bogota to ${metroCode} above ${threshold}",
                 "releaseStatus": "preview"
             },
             {
-                "name": "equinix.fabric.port.packets_dropped_rx.count",
-                "description": "Port inbound dropped packets count above ${threshold}",
+                "name": "equinix.fabric.metro.bl_{metroCode}.latency",
+                "description": "Metro latency from Brussels to ${metroCode} above ${threshold}",
                 "releaseStatus": "preview"
             },
             {
-                "name": "equinix.fabric.port.packets_dropped_tx.count",
-                "description": "Port outbound dropped packets count above ${threshold}",
+                "name": "equinix.fabric.metro.bo_{metroCode}.latency",
+                "description": "Metro latency from Boston to ${metroCode} above ${threshold}",
                 "releaseStatus": "preview"
             },
             {
-                "name": "equinix.fabric.port.packets_erred_rx.count",
-                "description": "Port inbound erred packets count above ${threshold}",
+                "name": "equinix.fabric.metro.bx_{metroCode}.latency",
+                "description": "Metro latency from Bordeaux to ${metroCode} above ${threshold}",
                 "releaseStatus": "preview"
             },
             {
-                "name": "equinix.fabric.port.packets_erred_tx.count",
-                "description": "Port outbound erred packets count above ${threshold}",
+                "name": "equinix.fabric.metro.ca_{metroCode}.latency",
+                "description": "Metro latency from Canberra to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.ch_{metroCode}.latency",
+                "description": "Metro latency from Chicago to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.cl_{metroCode}.latency",
+                "description": "Metro latency from Calgary to  ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.cu_{metroCode}.latency",
+                "description": "Metro latency from Culpeper to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.da_{metroCode}.latency",
+                "description": "Metro latency from Dallas to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.db_{metroCode}.latency",
+                "description": "Metro latency from Dublin to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.dc_{metroCode}.latency",
+                "description": "Metro latency from Ashburn to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.de_{metroCode}.latency",
+                "description": "Metro latency from Denver to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.dx_{metroCode}.latency",
+                "description": "Metro latency from Dubai to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.fr_{metroCode}.latency",
+                "description": "Metro latency from Frankfurt to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.gv_{metroCode}.latency",
+                "description": "Metro latency from Geneva to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.he_{metroCode}.latency",
+                "description": "Metro latency from Helsinki to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.hh_{metroCode}.latency",
+                "description": "Metro latency from Hamburg to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.hk_{metroCode}.latency",
+                "description": "Metro latency from Hong Kong to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.ho_{metroCode}.latency",
+                "description": "Metro latency from Houston to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.il_{metroCode}.latency",
+                "description": "Metro latency from Istanbul to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.jh_{metroCode}.latency",
+                "description": "Metro latency from Johor to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.ka_{metroCode}.latency",
+                "description": "Metro latency from Kamloops to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.kl_{metroCode}.latency",
+                "description": "Metro latency from Kuala Lumpur to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.la_{metroCode}.latency",
+                "description": "Metro latency from Los Angeles to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.ld_{metroCode}.latency",
+                "description": "Metro latency from London to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.lm_{metroCode}.latency",
+                "description": "Metro latency from Lima to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.ls_{metroCode}.latency",
+                "description": "Metro latency from Lisbon to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.ma_{metroCode}.latency",
+                "description": "Metro latency from Manchester to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.mb_{metroCode}.latency",
+                "description": "Metro latency from Mumbai to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.md_{metroCode}.latency",
+                "description": "Metro latency from Madrid to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.me_{metroCode}.latency",
+                "description": "Metro latency from Melbourne to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.mi_{metroCode}.latency",
+                "description": "Metro latency from Miami to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.ml_{metroCode}.latency",
+                "description": "Metro latency from Milan to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.mo_{metroCode}.latency",
+                "description": "Metro latency from Monterrey to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.mt_{metroCode}.latency",
+                "description": "Metro latency from Montreal to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.mu_{metroCode}.latency",
+                "description": "Metro latency from Munich to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.mx_{metroCode}.latency",
+                "description": "Metro latency from Mexico City to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.ny_{metroCode}.latency",
+                "description": "Metro latency from New York to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.os_{metroCode}.latency",
+                "description": "Metro latency from Osaka to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.ot_{metroCode}.latency",
+                "description": "Metro latency from Ottawa to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.pa_{metroCode}.latency",
+                "description": "Metro latency from Paris to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.pe_{metroCode}.latency",
+                "description": "Metro latency from Perth to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.ph_{metroCode}.latency",
+                "description": "Metro latency from Philadelphia to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.rj_{metroCode}.latency",
+                "description": "Metro latency from Rio de Janeiro to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.se_{metroCode}.latency",
+                "description": "Metro latency from Seattle to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.sg_{metroCode}.latency",
+                "description": "Metro latency from Singapore to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.sk_{metroCode}.latency",
+                "description": "Metro latency from Stockholm to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.sl_{metroCode}.latency",
+                "description": "Metro latency from Seoul to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.so_{metroCode}.latency",
+                "description": "Metro latency from Sofia to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.sp_{metroCode}.latency",
+                "description": "Metro latency from Sao Paulo to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.st_{metroCode}.latency",
+                "description": "Metro latency from Santiago to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.sv_{metroCode}.latency",
+                "description": "Metro latency from Silicon Valley to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.sy_{metroCode}.latency",
+                "description": "Metro latency from Sydney to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.tr_{metroCode}.latency",
+                "description": "Metro latency from Toronto to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.ty_{metroCode}.latency",
+                "description": "Metro latency from Tokyo to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.va_{metroCode}.latency",
+                "description": "Metro latency from Vancouver to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.wa_{metroCode}.latency",
+                "description": "Metro latency from Warsaw to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.wi_{metroCode}.latency",
+                "description": "Metro latency from Winnipeg to ${metroCode} above ${threshold}",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.zh_{metroCode}.latency",
+                "description": "Metro latency from Zurich to ${metroCode} above ${threshold}",
                 "releaseStatus": "preview"
             }
         ]

--- a/DataLoader.json
+++ b/DataLoader.json
@@ -1347,36 +1347,6 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.port.bandwidth_rx.usage",
-                "description": "Port inbound bandwidth usage above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.port.bandwidth_tx.usage",
-                "description": "Port outbound bandwidth usage above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.port.packets_dropped_rx.count",
-                "description": "Port inbound dropped packets count above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.port.packets_dropped_tx.count",
-                "description": "Port outbound dropped packets count above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.port.packets_erred_rx.count",
-                "description": "Port inbound erred packets count above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.port.packets_erred_tx.count",
-                "description": "Port outbound erred packets count above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.router.installed_routes_ipv4.utilization",
                 "description": "Utilization of router '${router_name}' total IPv4 routes reached ${threshold}",
                 "releaseStatus": "released"

--- a/DataLoader.json
+++ b/DataLoader.json
@@ -1327,8 +1327,23 @@
                 "releaseStatus": "released"
             },
             {
+                "name": "equinix.fabric.metro.am_{metroCode}.latency",
+                "description": "Metro latency from Amsterdam to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
                 "name": "equinix.fabric.metro.at_{metroCode}.latency",
                 "description": "Metro latency from Atlanta to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.at_{metroCode}.latency",
+                "description": "Metro latency from Atlanta to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.ba_{metroCode}.latency",
+                "description": "Metro latency from Barcelona to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
@@ -1342,8 +1357,23 @@
                 "releaseStatus": "released"
             },
             {
+                "name": "equinix.fabric.metro.bg_{metroCode}.latency",
+                "description": "Metro latency from Bogota to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
                 "name": "equinix.fabric.metro.bl_{metroCode}.latency",
                 "description": "Metro latency from Brussels to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.bl_{metroCode}.latency",
+                "description": "Metro latency from Brussels to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.bo_{metroCode}.latency",
+                "description": "Metro latency from Boston to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
@@ -1357,8 +1387,23 @@
                 "releaseStatus": "released"
             },
             {
+                "name": "equinix.fabric.metro.bx_{metroCode}.latency",
+                "description": "Metro latency from Bordeaux to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
                 "name": "equinix.fabric.metro.ca_{metroCode}.latency",
                 "description": "Metro latency from Canberra to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.ca_{metroCode}.latency",
+                "description": "Metro latency from Canberra to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.ch_{metroCode}.latency",
+                "description": "Metro latency from Chicago to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
@@ -1372,8 +1417,23 @@
                 "releaseStatus": "released"
             },
             {
+                "name": "equinix.fabric.metro.cl_{metroCode}.latency",
+                "description": "Metro latency from Calgary to  ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
                 "name": "equinix.fabric.metro.cu_{metroCode}.latency",
                 "description": "Metro latency from Culpeper to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.cu_{metroCode}.latency",
+                "description": "Metro latency from Culpeper to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.da_{metroCode}.latency",
+                "description": "Metro latency from Dallas to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
@@ -1387,8 +1447,23 @@
                 "releaseStatus": "released"
             },
             {
+                "name": "equinix.fabric.metro.db_{metroCode}.latency",
+                "description": "Metro latency from Dublin to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
                 "name": "equinix.fabric.metro.dc_{metroCode}.latency",
                 "description": "Metro latency from Ashburn to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.dc_{metroCode}.latency",
+                "description": "Metro latency from Ashburn to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.de_{metroCode}.latency",
+                "description": "Metro latency from Denver to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
@@ -1402,8 +1477,23 @@
                 "releaseStatus": "released"
             },
             {
+                "name": "equinix.fabric.metro.dx_{metroCode}.latency",
+                "description": "Metro latency from Dubai to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
                 "name": "equinix.fabric.metro.fr_{metroCode}.latency",
                 "description": "Metro latency from Frankfurt to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.fr_{metroCode}.latency",
+                "description": "Metro latency from Frankfurt to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.gv_{metroCode}.latency",
+                "description": "Metro latency from Geneva to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
@@ -1417,8 +1507,23 @@
                 "releaseStatus": "released"
             },
             {
+                "name": "equinix.fabric.metro.he_{metroCode}.latency",
+                "description": "Metro latency from Helsinki to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
                 "name": "equinix.fabric.metro.hh_{metroCode}.latency",
                 "description": "Metro latency from Hamburg to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.hh_{metroCode}.latency",
+                "description": "Metro latency from Hamburg to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.hk_{metroCode}.latency",
+                "description": "Metro latency from Hong Kong to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
@@ -1432,8 +1537,23 @@
                 "releaseStatus": "released"
             },
             {
+                "name": "equinix.fabric.metro.ho_{metroCode}.latency",
+                "description": "Metro latency from Houston to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
                 "name": "equinix.fabric.metro.il_{metroCode}.latency",
                 "description": "Metro latency from Istanbul to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.il_{metroCode}.latency",
+                "description": "Metro latency from Istanbul to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.jh_{metroCode}.latency",
+                "description": "Metro latency from Johor to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
@@ -1447,8 +1567,23 @@
                 "releaseStatus": "released"
             },
             {
+                "name": "equinix.fabric.metro.ka_{metroCode}.latency",
+                "description": "Metro latency from Kamloops to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
                 "name": "equinix.fabric.metro.kl_{metroCode}.latency",
                 "description": "Metro latency from Kuala Lumpur to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.kl_{metroCode}.latency",
+                "description": "Metro latency from Kuala Lumpur to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.la_{metroCode}.latency",
+                "description": "Metro latency from Los Angeles to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
@@ -1462,8 +1597,23 @@
                 "releaseStatus": "released"
             },
             {
+                "name": "equinix.fabric.metro.ld_{metroCode}.latency",
+                "description": "Metro latency from London to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
                 "name": "equinix.fabric.metro.lm_{metroCode}.latency",
                 "description": "Metro latency from Lima to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.lm_{metroCode}.latency",
+                "description": "Metro latency from Lima to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.ls_{metroCode}.latency",
+                "description": "Metro latency from Lisbon to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
@@ -1477,8 +1627,23 @@
                 "releaseStatus": "released"
             },
             {
+                "name": "equinix.fabric.metro.ma_{metroCode}.latency",
+                "description": "Metro latency from Manchester to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
                 "name": "equinix.fabric.metro.mb_{metroCode}.latency",
                 "description": "Metro latency from Mumbai to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.mb_{metroCode}.latency",
+                "description": "Metro latency from Mumbai to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.md_{metroCode}.latency",
+                "description": "Metro latency from Madrid to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
@@ -1492,8 +1657,23 @@
                 "releaseStatus": "released"
             },
             {
+                "name": "equinix.fabric.metro.me_{metroCode}.latency",
+                "description": "Metro latency from Melbourne to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
                 "name": "equinix.fabric.metro.mi_{metroCode}.latency",
                 "description": "Metro latency from Miami to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.mi_{metroCode}.latency",
+                "description": "Metro latency from Miami to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.ml_{metroCode}.latency",
+                "description": "Metro latency from Milan to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
@@ -1507,8 +1687,23 @@
                 "releaseStatus": "released"
             },
             {
+                "name": "equinix.fabric.metro.mo_{metroCode}.latency",
+                "description": "Metro latency from Monterrey to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
                 "name": "equinix.fabric.metro.mt_{metroCode}.latency",
                 "description": "Metro latency from Montreal to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.mt_{metroCode}.latency",
+                "description": "Metro latency from Montreal to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.mu_{metroCode}.latency",
+                "description": "Metro latency from Munich to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
@@ -1522,8 +1717,23 @@
                 "releaseStatus": "released"
             },
             {
+                "name": "equinix.fabric.metro.mx_{metroCode}.latency",
+                "description": "Metro latency from Mexico City to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
                 "name": "equinix.fabric.metro.ny_{metroCode}.latency",
                 "description": "Metro latency from New York to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.ny_{metroCode}.latency",
+                "description": "Metro latency from New York to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.os_{metroCode}.latency",
+                "description": "Metro latency from Osaka to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
@@ -1537,8 +1747,23 @@
                 "releaseStatus": "released"
             },
             {
+                "name": "equinix.fabric.metro.ot_{metroCode}.latency",
+                "description": "Metro latency from Ottawa to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
                 "name": "equinix.fabric.metro.pa_{metroCode}.latency",
                 "description": "Metro latency from Paris to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.pa_{metroCode}.latency",
+                "description": "Metro latency from Paris to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.pe_{metroCode}.latency",
+                "description": "Metro latency from Perth to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
@@ -1552,8 +1777,23 @@
                 "releaseStatus": "released"
             },
             {
+                "name": "equinix.fabric.metro.ph_{metroCode}.latency",
+                "description": "Metro latency from Philadelphia to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
                 "name": "equinix.fabric.metro.rj_{metroCode}.latency",
                 "description": "Metro latency from Rio de Janeiro to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.rj_{metroCode}.latency",
+                "description": "Metro latency from Rio de Janeiro to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.se_{metroCode}.latency",
+                "description": "Metro latency from Seattle to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
@@ -1567,8 +1807,23 @@
                 "releaseStatus": "released"
             },
             {
+                "name": "equinix.fabric.metro.sg_{metroCode}.latency",
+                "description": "Metro latency from Singapore to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
                 "name": "equinix.fabric.metro.sk_{metroCode}.latency",
                 "description": "Metro latency from Stockholm to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.sk_{metroCode}.latency",
+                "description": "Metro latency from Stockholm to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.sl_{metroCode}.latency",
+                "description": "Metro latency from Seoul to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
@@ -1582,8 +1837,23 @@
                 "releaseStatus": "released"
             },
             {
+                "name": "equinix.fabric.metro.so_{metroCode}.latency",
+                "description": "Metro latency from Sofia to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
                 "name": "equinix.fabric.metro.sp_{metroCode}.latency",
                 "description": "Metro latency from Sao Paulo to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.sp_{metroCode}.latency",
+                "description": "Metro latency from Sao Paulo to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.st_{metroCode}.latency",
+                "description": "Metro latency from Santiago to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
@@ -1597,8 +1867,23 @@
                 "releaseStatus": "released"
             },
             {
+                "name": "equinix.fabric.metro.sv_{metroCode}.latency",
+                "description": "Metro latency from Silicon Valley to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
                 "name": "equinix.fabric.metro.sy_{metroCode}.latency",
                 "description": "Metro latency from Sydney to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.sy_{metroCode}.latency",
+                "description": "Metro latency from Sydney to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.tr_{metroCode}.latency",
+                "description": "Metro latency from Toronto to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
@@ -1612,6 +1897,16 @@
                 "releaseStatus": "released"
             },
             {
+                "name": "equinix.fabric.metro.ty_{metroCode}.latency",
+                "description": "Metro latency from Tokyo to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.va_{metroCode}.latency",
+                "description": "Metro latency from Vancouver to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
                 "name": "equinix.fabric.metro.va_{metroCode}.latency",
                 "description": "Metro latency from Vancouver to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
@@ -1622,8 +1917,23 @@
                 "releaseStatus": "released"
             },
             {
+                "name": "equinix.fabric.metro.wa_{metroCode}.latency",
+                "description": "Metro latency from Warsaw to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
                 "name": "equinix.fabric.metro.wi_{metroCode}.latency",
                 "description": "Metro latency from Winnipeg to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.wi_{metroCode}.latency",
+                "description": "Metro latency from Winnipeg to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.zh_{metroCode}.latency",
+                "description": "Metro latency from Zurich to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
@@ -1670,316 +1980,6 @@
                 "name": "equinix.fabric.router.installed_routes_ipv6.utilization",
                 "description": "Utilization of router '${router_name}' total IPv6 routes reached ${threshold}",
                 "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.am_{metroCode}.latency",
-                "description": "Metro latency from Amsterdam to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.at_{metroCode}.latency",
-                "description": "Metro latency from Atlanta to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.ba_{metroCode}.latency",
-                "description": "Metro latency from Barcelona to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.bg_{metroCode}.latency",
-                "description": "Metro latency from Bogota to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.bl_{metroCode}.latency",
-                "description": "Metro latency from Brussels to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.bo_{metroCode}.latency",
-                "description": "Metro latency from Boston to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.bx_{metroCode}.latency",
-                "description": "Metro latency from Bordeaux to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.ca_{metroCode}.latency",
-                "description": "Metro latency from Canberra to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.ch_{metroCode}.latency",
-                "description": "Metro latency from Chicago to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.cl_{metroCode}.latency",
-                "description": "Metro latency from Calgary to  ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.cu_{metroCode}.latency",
-                "description": "Metro latency from Culpeper to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.da_{metroCode}.latency",
-                "description": "Metro latency from Dallas to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.db_{metroCode}.latency",
-                "description": "Metro latency from Dublin to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.dc_{metroCode}.latency",
-                "description": "Metro latency from Ashburn to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.de_{metroCode}.latency",
-                "description": "Metro latency from Denver to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.dx_{metroCode}.latency",
-                "description": "Metro latency from Dubai to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.fr_{metroCode}.latency",
-                "description": "Metro latency from Frankfurt to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.gv_{metroCode}.latency",
-                "description": "Metro latency from Geneva to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.he_{metroCode}.latency",
-                "description": "Metro latency from Helsinki to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.hh_{metroCode}.latency",
-                "description": "Metro latency from Hamburg to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.hk_{metroCode}.latency",
-                "description": "Metro latency from Hong Kong to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.ho_{metroCode}.latency",
-                "description": "Metro latency from Houston to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.il_{metroCode}.latency",
-                "description": "Metro latency from Istanbul to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.jh_{metroCode}.latency",
-                "description": "Metro latency from Johor to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.ka_{metroCode}.latency",
-                "description": "Metro latency from Kamloops to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.kl_{metroCode}.latency",
-                "description": "Metro latency from Kuala Lumpur to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.la_{metroCode}.latency",
-                "description": "Metro latency from Los Angeles to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.ld_{metroCode}.latency",
-                "description": "Metro latency from London to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.lm_{metroCode}.latency",
-                "description": "Metro latency from Lima to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.ls_{metroCode}.latency",
-                "description": "Metro latency from Lisbon to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.ma_{metroCode}.latency",
-                "description": "Metro latency from Manchester to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.mb_{metroCode}.latency",
-                "description": "Metro latency from Mumbai to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.md_{metroCode}.latency",
-                "description": "Metro latency from Madrid to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.me_{metroCode}.latency",
-                "description": "Metro latency from Melbourne to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.mi_{metroCode}.latency",
-                "description": "Metro latency from Miami to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.ml_{metroCode}.latency",
-                "description": "Metro latency from Milan to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.mo_{metroCode}.latency",
-                "description": "Metro latency from Monterrey to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.mt_{metroCode}.latency",
-                "description": "Metro latency from Montreal to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.mu_{metroCode}.latency",
-                "description": "Metro latency from Munich to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.mx_{metroCode}.latency",
-                "description": "Metro latency from Mexico City to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.ny_{metroCode}.latency",
-                "description": "Metro latency from New York to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.os_{metroCode}.latency",
-                "description": "Metro latency from Osaka to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.ot_{metroCode}.latency",
-                "description": "Metro latency from Ottawa to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.pa_{metroCode}.latency",
-                "description": "Metro latency from Paris to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.pe_{metroCode}.latency",
-                "description": "Metro latency from Perth to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.ph_{metroCode}.latency",
-                "description": "Metro latency from Philadelphia to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.rj_{metroCode}.latency",
-                "description": "Metro latency from Rio de Janeiro to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.se_{metroCode}.latency",
-                "description": "Metro latency from Seattle to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.sg_{metroCode}.latency",
-                "description": "Metro latency from Singapore to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.sk_{metroCode}.latency",
-                "description": "Metro latency from Stockholm to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.sl_{metroCode}.latency",
-                "description": "Metro latency from Seoul to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.so_{metroCode}.latency",
-                "description": "Metro latency from Sofia to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.sp_{metroCode}.latency",
-                "description": "Metro latency from Sao Paulo to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.st_{metroCode}.latency",
-                "description": "Metro latency from Santiago to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.sv_{metroCode}.latency",
-                "description": "Metro latency from Silicon Valley to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.sy_{metroCode}.latency",
-                "description": "Metro latency from Sydney to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.tr_{metroCode}.latency",
-                "description": "Metro latency from Toronto to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.ty_{metroCode}.latency",
-                "description": "Metro latency from Tokyo to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.va_{metroCode}.latency",
-                "description": "Metro latency from Vancouver to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.wa_{metroCode}.latency",
-                "description": "Metro latency from Warsaw to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.wi_{metroCode}.latency",
-                "description": "Metro latency from Winnipeg to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.metro.zh_{metroCode}.latency",
-                "description": "Metro latency from Zurich to ${metroCode} above ${threshold}",
-                "releaseStatus": "preview"
             }
         ]
     },

--- a/DataLoader.json
+++ b/DataLoader.json
@@ -626,322 +626,322 @@
             },
             {
                 "name": "equinix.fabric.metro.am_{metroCode}.latency",
-                "description": "Amsterdam to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Amsterdam to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.at_{metroCode}.latency",
-                "description": "Atlanta to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Atlanta to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ba_{metroCode}.latency",
-                "description": "Barcelona to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Barcelona to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.bg_{metroCode}.latency",
-                "description": "Bogota to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Bogota to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.bl_{metroCode}.latency",
-                "description": "Brussels to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Brussels to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.bo_{metroCode}.latency",
-                "description": "Boston to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Boston to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.bx_{metroCode}.latency",
-                "description": "Bordeaux to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Bordeaux to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ca_{metroCode}.latency",
-                "description": "Canberra to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Canberra to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ch_{metroCode}.latency",
-                "description": "Chicago to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Chicago to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.cl_{metroCode}.latency",
-                "description": "Calgary to  ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Calgary to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.cu_{metroCode}.latency",
-                "description": "Culpeper to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Culpeper to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.da_{metroCode}.latency",
-                "description": "Dallas to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Dallas to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.db_{metroCode}.latency",
-                "description": "Dublin to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Dublin to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.dc_{metroCode}.latency",
-                "description": "Ashburn to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Ashburn to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.de_{metroCode}.latency",
-                "description": "Denver to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Denver to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.dx_{metroCode}.latency",
-                "description": "Dubai to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Dubai to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.fr_{metroCode}.latency",
-                "description": "Frankfurt to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Frankfurt to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.gv_{metroCode}.latency",
-                "description": "Geneva to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Geneva to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.he_{metroCode}.latency",
-                "description": "Helsinki to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Helsinki to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.hh_{metroCode}.latency",
-                "description": "Hamburg to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Hamburg to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.hk_{metroCode}.latency",
-                "description": "Hong Kong to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Hong Kong to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ho_{metroCode}.latency",
-                "description": "Houston to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Houston to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.il_{metroCode}.latency",
-                "description": "Istanbul to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Istanbul to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.jh_{metroCode}.latency",
-                "description": "Johor to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Johor to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.jk_{metroCode}.latency",
-                "description": "Jakarta to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Jakarta to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.jn_{metroCode}.latency",
-                "description": "Johannesburg to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Johannesburg to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ka_{metroCode}.latency",
-                "description": "Kamloops to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Kamloops to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.kl_{metroCode}.latency",
-                "description": "Kuala Lumpur to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Kuala Lumpur to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.la_{metroCode}.latency",
-                "description": "Los Angeles to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Los Angeles to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ld_{metroCode}.latency",
-                "description": "London to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "London to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.lm_{metroCode}.latency",
-                "description": "Lima to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Lima to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ls_{metroCode}.latency",
-                "description": "Lisbon to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Lisbon to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ma_{metroCode}.latency",
-                "description": "Manchester to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Manchester to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.mb_{metroCode}.latency",
-                "description": "Mumbai to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Mumbai to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.md_{metroCode}.latency",
-                "description": "Madrid to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Madrid to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.me_{metroCode}.latency",
-                "description": "Melbourne to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Melbourne to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.mi_{metroCode}.latency",
-                "description": "Miami to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Miami to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ml_{metroCode}.latency",
-                "description": "Milan to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Milan to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.mo_{metroCode}.latency",
-                "description": "Monterrey to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Monterrey to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.mt_{metroCode}.latency",
-                "description": "Montreal to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Montreal to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.mu_{metroCode}.latency",
-                "description": "Munich to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Munich to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.mx_{metroCode}.latency",
-                "description": "Mexico City to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Mexico City to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ny_{metroCode}.latency",
-                "description": "New York to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "New York to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.os_{metroCode}.latency",
-                "description": "Osaka to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Osaka to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ot_{metroCode}.latency",
-                "description": "Ottawa to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Ottawa to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.pa_{metroCode}.latency",
-                "description": "Paris to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Paris to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.pe_{metroCode}.latency",
-                "description": "Perth to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Perth to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ph_{metroCode}.latency",
-                "description": "Philadelphia to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Philadelphia to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.rj_{metroCode}.latency",
-                "description": "Rio de Janeiro to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Rio de Janeiro to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.se_{metroCode}.latency",
-                "description": "Seattle to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Seattle to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.sg_{metroCode}.latency",
-                "description": "Singapore to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Singapore to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.sk_{metroCode}.latency",
-                "description": "Stockholm to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Stockholm to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.sl_{metroCode}.latency",
-                "description": "Seoul to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Seoul to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.so_{metroCode}.latency",
-                "description": "Sofia to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Sofia to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.sp_{metroCode}.latency",
-                "description": "Sao Paulo to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Sao Paulo to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.st_{metroCode}.latency",
-                "description": "Santiago to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Santiago to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.sv_{metroCode}.latency",
-                "description": "Silicon Valley to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Silicon Valley to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.sy_{metroCode}.latency",
-                "description": "Sydney to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Sydney to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.tr_{metroCode}.latency",
-                "description": "Toronto to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Toronto to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ty_{metroCode}.latency",
-                "description": "Tokyo to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Tokyo to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.va_{metroCode}.latency",
-                "description": "Vancouver to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Vancouver to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.wa_{metroCode}.latency",
-                "description": "Warsaw to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Warsaw to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.wi_{metroCode}.latency",
-                "description": "Winnipeg to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Winnipeg to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.zh_{metroCode}.latency",
-                "description": "Zurich to ${metroCode} intermetro latency, average in milliseconds",
+                "description": "Zurich to ${metro} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1018,322 +1018,322 @@
             },
             {
                 "name": "equinix.fabric.metro.am_{metroCode}.latency",
-                "description": "Metro latency from Amsterdam to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Amsterdam to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.at_{metroCode}.latency",
-                "description": "Metro latency from Atlanta to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Atlanta to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ba_{metroCode}.latency",
-                "description": "Metro latency from Barcelona to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Barcelona to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.bg_{metroCode}.latency",
-                "description": "Metro latency from Bogota to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Bogota to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.bl_{metroCode}.latency",
-                "description": "Metro latency from Brussels to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Brussels to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.bo_{metroCode}.latency",
-                "description": "Metro latency from Boston to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Boston to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.bx_{metroCode}.latency",
-                "description": "Metro latency from Bordeaux to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Bordeaux to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ca_{metroCode}.latency",
-                "description": "Metro latency from Canberra to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Canberra to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ch_{metroCode}.latency",
-                "description": "Metro latency from Chicago to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Chicago to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.cl_{metroCode}.latency",
-                "description": "Metro latency from Calgary to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Calgary to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.cu_{metroCode}.latency",
-                "description": "Metro latency from Culpeper to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Culpeper to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.da_{metroCode}.latency",
-                "description": "Metro latency from Dallas to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Dallas to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.db_{metroCode}.latency",
-                "description": "Metro latency from Dublin to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Dublin to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.dc_{metroCode}.latency",
-                "description": "Metro latency from Ashburn to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Ashburn to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.de_{metroCode}.latency",
-                "description": "Metro latency from Denver to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Denver to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.dx_{metroCode}.latency",
-                "description": "Metro latency from Dubai to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Dubai to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.fr_{metroCode}.latency",
-                "description": "Metro latency from Frankfurt to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Frankfurt to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.gv_{metroCode}.latency",
-                "description": "Metro latency from Geneva to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Geneva to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.he_{metroCode}.latency",
-                "description": "Metro latency from Helsinki to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Helsinki to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.hh_{metroCode}.latency",
-                "description": "Metro latency from Hamburg to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Hamburg to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.hk_{metroCode}.latency",
-                "description": "Metro latency from Hong Kong to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Hong Kong to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ho_{metroCode}.latency",
-                "description": "Metro latency from Houston to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Houston to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.il_{metroCode}.latency",
-                "description": "Metro latency from Istanbul to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Istanbul to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.jh_{metroCode}.latency",
-                "description": "Metro latency from Johor to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Johor to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.jk_{metroCode}.latency",
-                "description": "Metro latency from Jakarta to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Jakarta to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.jn_{metroCode}.latency",
-                "description": "Metro latency from Johannesburg to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Johannesburg to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ka_{metroCode}.latency",
-                "description": "Metro latency from Kamloops to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Kamloops to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.kl_{metroCode}.latency",
-                "description": "Metro latency from Kuala Lumpur to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Kuala Lumpur to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.la_{metroCode}.latency",
-                "description": "Metro latency from Los Angeles to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Los Angeles to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ld_{metroCode}.latency",
-                "description": "Metro latency from London to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from London to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.lm_{metroCode}.latency",
-                "description": "Metro latency from Lima to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Lima to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ls_{metroCode}.latency",
-                "description": "Metro latency from Lisbon to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Lisbon to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ma_{metroCode}.latency",
-                "description": "Metro latency from Manchester to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Manchester to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.mb_{metroCode}.latency",
-                "description": "Metro latency from Mumbai to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Mumbai to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.md_{metroCode}.latency",
-                "description": "Metro latency from Madrid to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Madrid to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.me_{metroCode}.latency",
-                "description": "Metro latency from Melbourne to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Melbourne to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.mi_{metroCode}.latency",
-                "description": "Metro latency from Miami to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Miami to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ml_{metroCode}.latency",
-                "description": "Metro latency from Milan to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Milan to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.mo_{metroCode}.latency",
-                "description": "Metro latency from Monterrey to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Monterrey to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.mt_{metroCode}.latency",
-                "description": "Metro latency from Montreal to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Montreal to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.mu_{metroCode}.latency",
-                "description": "Metro latency from Munich to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Munich to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.mx_{metroCode}.latency",
-                "description": "Metro latency from Mexico City to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Mexico City to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ny_{metroCode}.latency",
-                "description": "Metro latency from New York to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from New York to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.os_{metroCode}.latency",
-                "description": "Metro latency from Osaka to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Osaka to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ot_{metroCode}.latency",
-                "description": "Metro latency from Ottawa to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Ottawa to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.pa_{metroCode}.latency",
-                "description": "Metro latency from Paris to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Paris to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.pe_{metroCode}.latency",
-                "description": "Metro latency from Perth to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Perth to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ph_{metroCode}.latency",
-                "description": "Metro latency from Philadelphia to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Philadelphia to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.rj_{metroCode}.latency",
-                "description": "Metro latency from Rio de Janeiro to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Rio de Janeiro to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.se_{metroCode}.latency",
-                "description": "Metro latency from Seattle to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Seattle to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.sg_{metroCode}.latency",
-                "description": "Metro latency from Singapore to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Singapore to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.sk_{metroCode}.latency",
-                "description": "Metro latency from Stockholm to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Stockholm to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.sl_{metroCode}.latency",
-                "description": "Metro latency from Seoul to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Seoul to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.so_{metroCode}.latency",
-                "description": "Metro latency from Sofia to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Sofia to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.sp_{metroCode}.latency",
-                "description": "Metro latency from Sao Paulo to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Sao Paulo to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.st_{metroCode}.latency",
-                "description": "Metro latency from Santiago to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Santiago to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.sv_{metroCode}.latency",
-                "description": "Metro latency from Silicon Valley to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Silicon Valley to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.sy_{metroCode}.latency",
-                "description": "Metro latency from Sydney to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Sydney to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.tr_{metroCode}.latency",
-                "description": "Metro latency from Toronto to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Toronto to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ty_{metroCode}.latency",
-                "description": "Metro latency from Tokyo to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Tokyo to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.va_{metroCode}.latency",
-                "description": "Metro latency from Vancouver to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Vancouver to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.wa_{metroCode}.latency",
-                "description": "Metro latency from Warsaw to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Warsaw to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.wi_{metroCode}.latency",
-                "description": "Metro latency from Winnipeg to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Winnipeg to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.zh_{metroCode}.latency",
-                "description": "Metro latency from Zurich to ${metroCode} is ${operator} ${operand} milliseconds",
+                "description": "Metro latency from Zurich to ${metro} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {

--- a/DataLoader.json
+++ b/DataLoader.json
@@ -1381,6 +1381,16 @@
     "identity": {
         "cloudeventTypes": [
             {
+                "name": "equinix.identity.organization.user.added",
+                "description": "User added to org event",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.identity.organization.user.removed",
+                "description": "User removed from org event",
+                "releaseStatus": "released"
+            },
+            {
                 "name": "equinix.identity.user.activity.logged_in",
                 "description": "User loggedIn event",
                 "releaseStatus": "released"
@@ -1389,16 +1399,6 @@
                 "name": "equinix.identity.user.activity.logged_out",
                 "description": "User loggedOut event",
                 "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.identity.organization.user.added",
-                "description": "User added to org event",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.identity.organization.user.removed",
-                "description": "User removed from org event",
-                "releaseStatus": "preview"
             }
         ],
         "metricNames": [],

--- a/DataLoader.json
+++ b/DataLoader.json
@@ -129,7 +129,7 @@
             },
             {
                 "name": "equinix.fabric.metric",
-                "description": "",
+                "description": "Metrics collected",
                 "releaseStatus": "released"
             },
             {

--- a/DataLoader.json
+++ b/DataLoader.json
@@ -745,6 +745,16 @@
                 "releaseStatus": "released"
             },
             {
+                "name": "equinix.fabric.metro.jk_{metroCode}.latency",
+                "description": "Jakarta to ${metroCode} intermetro latency, average in milliseconds",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.jn_{metroCode}.latency",
+                "description": "Johannesburg to ${metroCode} intermetro latency, average in milliseconds",
+                "releaseStatus": "released"
+            },
+            {
                 "name": "equinix.fabric.metro.ka_{metroCode}.latency",
                 "description": "Kamloops to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
@@ -1124,6 +1134,16 @@
             {
                 "name": "equinix.fabric.metro.jh_{metroCode}.latency",
                 "description": "Metro latency from Johor to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.jk_{metroCode}.latency",
+                "description": "Metro latency from Jakarta to ${metroCode} above ${threshold}",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.metro.jn_{metroCode}.latency",
+                "description": "Metro latency from Johannesburg to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {

--- a/DataLoader.json
+++ b/DataLoader.json
@@ -978,162 +978,162 @@
         "alertNames": [
             {
                 "name": "equinix.fabric.connection.bandwidth_rx.usage",
-                "description": "Connection inbound bandwidth usage above ${threshold}",
+                "description": "Connection inbound bandwidth usage is ${operator} ${operand} bit/s",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.connection.bandwidth_tx.usage",
-                "description": "Connection outbound bandwidth usage above ${threshold}",
+                "description": "Connection outbound bandwidth usage is ${operator} ${operand} bit/s",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.connection.installed_routes_ipv4.utilization",
-                "description": "Utilization of connection '${connection_name}' active IPv4 routes reached ${threshold}",
+                "description": "Utilization of connection active IPv4 routes is ${operator} ${operand}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.connection.installed_routes_ipv6.utilization",
-                "description": "Utilization of connection '${connection_name}' active IPv6 routes reached ${threshold}",
+                "description": "Utilization of connection active IPv6 routes is ${operator} ${operand}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.connection.packets_dropped_rx_aside_rateexceeded.count",
-                "description": "Connection A side inbound dropped packets count above ${threshold}",
+                "description": "Connection A side inbound dropped packets count is ${operator} ${operand}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.connection.packets_dropped_rx_zside_rateexceeded.count",
-                "description": "Connection Z side inbound dropped packets count above ${threshold}",
+                "description": "Connection Z side inbound dropped packets count is ${operator} ${operand}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.connection.packets_dropped_tx_aside_rateexceeded.count",
-                "description": "Connection A side outbound dropped packets count above ${threshold}",
+                "description": "Connection A side outbound dropped packets count is ${operator} ${operand}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.connection.packets_dropped_tx_zside_rateexceeded.count",
-                "description": "Connection Z side outbound dropped packets count above ${threshold}",
+                "description": "Connection Z side outbound dropped packets count is ${operator} ${operand}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.am_{metroCode}.latency",
-                "description": "Metro latency from Amsterdam to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Amsterdam to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.at_{metroCode}.latency",
-                "description": "Metro latency from Atlanta to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Atlanta to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ba_{metroCode}.latency",
-                "description": "Metro latency from Barcelona to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Barcelona to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.bg_{metroCode}.latency",
-                "description": "Metro latency from Bogota to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Bogota to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.bl_{metroCode}.latency",
-                "description": "Metro latency from Brussels to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Brussels to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.bo_{metroCode}.latency",
-                "description": "Metro latency from Boston to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Boston to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.bx_{metroCode}.latency",
-                "description": "Metro latency from Bordeaux to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Bordeaux to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ca_{metroCode}.latency",
-                "description": "Metro latency from Canberra to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Canberra to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ch_{metroCode}.latency",
-                "description": "Metro latency from Chicago to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Chicago to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.cl_{metroCode}.latency",
-                "description": "Metro latency from Calgary to  ${metroCode} above ${threshold}",
+                "description": "Metro latency from Calgary to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.cu_{metroCode}.latency",
-                "description": "Metro latency from Culpeper to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Culpeper to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.da_{metroCode}.latency",
-                "description": "Metro latency from Dallas to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Dallas to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.db_{metroCode}.latency",
-                "description": "Metro latency from Dublin to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Dublin to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.dc_{metroCode}.latency",
-                "description": "Metro latency from Ashburn to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Ashburn to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.de_{metroCode}.latency",
-                "description": "Metro latency from Denver to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Denver to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.dx_{metroCode}.latency",
-                "description": "Metro latency from Dubai to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Dubai to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.fr_{metroCode}.latency",
-                "description": "Metro latency from Frankfurt to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Frankfurt to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.gv_{metroCode}.latency",
-                "description": "Metro latency from Geneva to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Geneva to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.he_{metroCode}.latency",
-                "description": "Metro latency from Helsinki to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Helsinki to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.hh_{metroCode}.latency",
-                "description": "Metro latency from Hamburg to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Hamburg to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.hk_{metroCode}.latency",
-                "description": "Metro latency from Hong Kong to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Hong Kong to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ho_{metroCode}.latency",
-                "description": "Metro latency from Houston to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Houston to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.il_{metroCode}.latency",
-                "description": "Metro latency from Istanbul to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Istanbul to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.jh_{metroCode}.latency",
-                "description": "Metro latency from Johor to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Johor to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1148,232 +1148,232 @@
             },
             {
                 "name": "equinix.fabric.metro.ka_{metroCode}.latency",
-                "description": "Metro latency from Kamloops to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Kamloops to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.kl_{metroCode}.latency",
-                "description": "Metro latency from Kuala Lumpur to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Kuala Lumpur to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.la_{metroCode}.latency",
-                "description": "Metro latency from Los Angeles to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Los Angeles to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ld_{metroCode}.latency",
-                "description": "Metro latency from London to ${metroCode} above ${threshold}",
+                "description": "Metro latency from London to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.lm_{metroCode}.latency",
-                "description": "Metro latency from Lima to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Lima to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ls_{metroCode}.latency",
-                "description": "Metro latency from Lisbon to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Lisbon to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ma_{metroCode}.latency",
-                "description": "Metro latency from Manchester to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Manchester to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.mb_{metroCode}.latency",
-                "description": "Metro latency from Mumbai to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Mumbai to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.md_{metroCode}.latency",
-                "description": "Metro latency from Madrid to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Madrid to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.me_{metroCode}.latency",
-                "description": "Metro latency from Melbourne to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Melbourne to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.mi_{metroCode}.latency",
-                "description": "Metro latency from Miami to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Miami to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ml_{metroCode}.latency",
-                "description": "Metro latency from Milan to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Milan to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.mo_{metroCode}.latency",
-                "description": "Metro latency from Monterrey to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Monterrey to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.mt_{metroCode}.latency",
-                "description": "Metro latency from Montreal to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Montreal to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.mu_{metroCode}.latency",
-                "description": "Metro latency from Munich to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Munich to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.mx_{metroCode}.latency",
-                "description": "Metro latency from Mexico City to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Mexico City to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ny_{metroCode}.latency",
-                "description": "Metro latency from New York to ${metroCode} above ${threshold}",
+                "description": "Metro latency from New York to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.os_{metroCode}.latency",
-                "description": "Metro latency from Osaka to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Osaka to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ot_{metroCode}.latency",
-                "description": "Metro latency from Ottawa to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Ottawa to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.pa_{metroCode}.latency",
-                "description": "Metro latency from Paris to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Paris to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.pe_{metroCode}.latency",
-                "description": "Metro latency from Perth to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Perth to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ph_{metroCode}.latency",
-                "description": "Metro latency from Philadelphia to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Philadelphia to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.rj_{metroCode}.latency",
-                "description": "Metro latency from Rio de Janeiro to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Rio de Janeiro to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.se_{metroCode}.latency",
-                "description": "Metro latency from Seattle to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Seattle to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.sg_{metroCode}.latency",
-                "description": "Metro latency from Singapore to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Singapore to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.sk_{metroCode}.latency",
-                "description": "Metro latency from Stockholm to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Stockholm to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.sl_{metroCode}.latency",
-                "description": "Metro latency from Seoul to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Seoul to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.so_{metroCode}.latency",
-                "description": "Metro latency from Sofia to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Sofia to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.sp_{metroCode}.latency",
-                "description": "Metro latency from Sao Paulo to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Sao Paulo to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.st_{metroCode}.latency",
-                "description": "Metro latency from Santiago to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Santiago to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.sv_{metroCode}.latency",
-                "description": "Metro latency from Silicon Valley to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Silicon Valley to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.sy_{metroCode}.latency",
-                "description": "Metro latency from Sydney to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Sydney to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.tr_{metroCode}.latency",
-                "description": "Metro latency from Toronto to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Toronto to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.ty_{metroCode}.latency",
-                "description": "Metro latency from Tokyo to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Tokyo to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.va_{metroCode}.latency",
-                "description": "Metro latency from Vancouver to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Vancouver to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.wa_{metroCode}.latency",
-                "description": "Metro latency from Warsaw to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Warsaw to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.wi_{metroCode}.latency",
-                "description": "Metro latency from Winnipeg to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Winnipeg to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.metro.zh_{metroCode}.latency",
-                "description": "Metro latency from Zurich to ${metroCode} above ${threshold}",
+                "description": "Metro latency from Zurich to ${metroCode} is ${operator} ${operand} milliseconds",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.port.bandwidth_rx.usage",
-                "description": "Port inbound bandwidth usage above ${threshold}",
+                "description": "Port inbound bandwidth usage is ${operator} ${operand} bit/s",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.port.bandwidth_tx.usage",
-                "description": "Port outbound bandwidth usage above ${threshold}",
+                "description": "Port outbound bandwidth usage is ${operator} ${operand} bit/s",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.port.packets_dropped_rx.count",
-                "description": "Port inbound dropped packets count above ${threshold}",
+                "description": "Port inbound dropped packets count is ${operator} ${operand}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.port.packets_dropped_tx.count",
-                "description": "Port outbound dropped packets count above ${threshold}",
+                "description": "Port outbound dropped packets count is ${operator} ${operand}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.port.packets_erred_rx.count",
-                "description": "Port inbound erred packets count above ${threshold}",
+                "description": "Port inbound erred packets count is ${operator} ${operand}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.port.packets_erred_tx.count",
-                "description": "Port outbound erred packets count above ${threshold}",
+                "description": "Port outbound erred packets count is ${operator} ${operand}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.router.installed_routes_ipv4.utilization",
-                "description": "Utilization of router '${router_name}' total IPv4 routes reached ${threshold}",
+                "description": "Utilization of router total IPv4 routes is ${operator} ${operand}",
                 "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.router.installed_routes_ipv6.utilization",
-                "description": "Utilization of router '${router_name}' total IPv6 routes reached ${threshold}",
+                "description": "Utilization of router total IPv6 routes is ${operator} ${operand}",
                 "releaseStatus": "released"
             }
         ]

--- a/DataLoader.json
+++ b/DataLoader.json
@@ -188,6 +188,11 @@
                 "releaseStatus": "released"
             },
             {
+                "name": "equinix.fabric.metric",
+                "description": "Metrics collected",
+                "releaseStatus": "released"
+            },
+            {
                 "name": "equinix.fabric.network.attribute.changed",
                 "description": "network named ${network_name} attribute changed",
                 "releaseStatus": "released"

--- a/DataLoader.json
+++ b/DataLoader.json
@@ -128,11 +128,6 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metric",
-                "description": "Metrics collected",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.network.attribute.changed",
                 "description": "network named ${network_name} attribute changed",
                 "releaseStatus": "released"
@@ -635,23 +630,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.am_{metroCode}.latency",
-                "description": "Amsterdam to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.at_{metroCode}.latency",
                 "description": "Atlanta to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.at_{metroCode}.latency",
-                "description": "Atlanta to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.ba_{metroCode}.latency",
-                "description": "Barcelona to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
@@ -665,23 +645,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.bg_{metroCode}.latency",
-                "description": "Bogota to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.bl_{metroCode}.latency",
                 "description": "Brussels to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.bl_{metroCode}.latency",
-                "description": "Brussels to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.bo_{metroCode}.latency",
-                "description": "Boston to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
@@ -695,23 +660,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.bx_{metroCode}.latency",
-                "description": "Bordeaux to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.ca_{metroCode}.latency",
                 "description": "Canberra to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.ca_{metroCode}.latency",
-                "description": "Canberra to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.ch_{metroCode}.latency",
-                "description": "Chicago to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
@@ -725,23 +675,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.cl_{metroCode}.latency",
-                "description": "Calgary to  ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.cu_{metroCode}.latency",
                 "description": "Culpeper to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.cu_{metroCode}.latency",
-                "description": "Culpeper to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.da_{metroCode}.latency",
-                "description": "Dallas to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
@@ -755,23 +690,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.db_{metroCode}.latency",
-                "description": "Dublin to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.dc_{metroCode}.latency",
                 "description": "Ashburn to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.dc_{metroCode}.latency",
-                "description": "Ashburn to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.de_{metroCode}.latency",
-                "description": "Denver to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
@@ -785,23 +705,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.dx_{metroCode}.latency",
-                "description": "Dubai to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.fr_{metroCode}.latency",
                 "description": "Frankfurt to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.fr_{metroCode}.latency",
-                "description": "Frankfurt to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.gv_{metroCode}.latency",
-                "description": "Geneva to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
@@ -815,23 +720,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.he_{metroCode}.latency",
-                "description": "Helsinki to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.hh_{metroCode}.latency",
                 "description": "Hamburg to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.hh_{metroCode}.latency",
-                "description": "Hamburg to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.hk_{metroCode}.latency",
-                "description": "Hong Kong to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
@@ -845,23 +735,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.ho_{metroCode}.latency",
-                "description": "Houston to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.il_{metroCode}.latency",
                 "description": "Istanbul to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.il_{metroCode}.latency",
-                "description": "Istanbul to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.jh_{metroCode}.latency",
-                "description": "Johor to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
@@ -875,23 +750,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.ka_{metroCode}.latency",
-                "description": "Kamloops to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.kl_{metroCode}.latency",
                 "description": "Kuala Lumpur to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.kl_{metroCode}.latency",
-                "description": "Kuala Lumpur to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.la_{metroCode}.latency",
-                "description": "Los Angeles to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
@@ -905,23 +765,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.ld_{metroCode}.latency",
-                "description": "London to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.lm_{metroCode}.latency",
                 "description": "Lima to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.lm_{metroCode}.latency",
-                "description": "Lima to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.ls_{metroCode}.latency",
-                "description": "Lisbon to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
@@ -935,23 +780,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.ma_{metroCode}.latency",
-                "description": "Manchester to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.mb_{metroCode}.latency",
                 "description": "Mumbai to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.mb_{metroCode}.latency",
-                "description": "Mumbai to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.md_{metroCode}.latency",
-                "description": "Madrid to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
@@ -965,23 +795,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.me_{metroCode}.latency",
-                "description": "Melbourne to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.mi_{metroCode}.latency",
                 "description": "Miami to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.mi_{metroCode}.latency",
-                "description": "Miami to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.ml_{metroCode}.latency",
-                "description": "Milan to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
@@ -995,23 +810,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.mo_{metroCode}.latency",
-                "description": "Monterrey to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.mt_{metroCode}.latency",
                 "description": "Montreal to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.mt_{metroCode}.latency",
-                "description": "Montreal to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.mu_{metroCode}.latency",
-                "description": "Munich to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1025,23 +825,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.mx_{metroCode}.latency",
-                "description": "Mexico City to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.ny_{metroCode}.latency",
                 "description": "New York to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.ny_{metroCode}.latency",
-                "description": "New York to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.os_{metroCode}.latency",
-                "description": "Osaka to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1055,23 +840,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.ot_{metroCode}.latency",
-                "description": "Ottawa to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.pa_{metroCode}.latency",
                 "description": "Paris to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.pa_{metroCode}.latency",
-                "description": "Paris to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.pe_{metroCode}.latency",
-                "description": "Perth to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1085,23 +855,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.ph_{metroCode}.latency",
-                "description": "Philadelphia to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.rj_{metroCode}.latency",
                 "description": "Rio de Janeiro to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.rj_{metroCode}.latency",
-                "description": "Rio de Janeiro to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.se_{metroCode}.latency",
-                "description": "Seattle to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1115,23 +870,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.sg_{metroCode}.latency",
-                "description": "Singapore to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.sk_{metroCode}.latency",
                 "description": "Stockholm to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.sk_{metroCode}.latency",
-                "description": "Stockholm to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.sl_{metroCode}.latency",
-                "description": "Seoul to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1145,23 +885,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.so_{metroCode}.latency",
-                "description": "Sofia to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.sp_{metroCode}.latency",
                 "description": "Sao Paulo to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.sp_{metroCode}.latency",
-                "description": "Sao Paulo to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.st_{metroCode}.latency",
-                "description": "Santiago to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1175,23 +900,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.sv_{metroCode}.latency",
-                "description": "Silicon Valley to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.sy_{metroCode}.latency",
                 "description": "Sydney to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.sy_{metroCode}.latency",
-                "description": "Sydney to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.tr_{metroCode}.latency",
-                "description": "Toronto to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1205,16 +915,6 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.ty_{metroCode}.latency",
-                "description": "Tokyo to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.va_{metroCode}.latency",
-                "description": "Vancouver to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.va_{metroCode}.latency",
                 "description": "Vancouver to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
@@ -1225,23 +925,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.wa_{metroCode}.latency",
-                "description": "Warsaw to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.wi_{metroCode}.latency",
                 "description": "Winnipeg to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.wi_{metroCode}.latency",
-                "description": "Winnipeg to ${metroCode} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.zh_{metroCode}.latency",
-                "description": "Zurich to ${metroCode} intermetro latency, average in milliseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1327,23 +1012,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.am_{metroCode}.latency",
-                "description": "Metro latency from Amsterdam to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.at_{metroCode}.latency",
                 "description": "Metro latency from Atlanta to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.at_{metroCode}.latency",
-                "description": "Metro latency from Atlanta to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.ba_{metroCode}.latency",
-                "description": "Metro latency from Barcelona to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
@@ -1357,23 +1027,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.bg_{metroCode}.latency",
-                "description": "Metro latency from Bogota to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.bl_{metroCode}.latency",
                 "description": "Metro latency from Brussels to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.bl_{metroCode}.latency",
-                "description": "Metro latency from Brussels to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.bo_{metroCode}.latency",
-                "description": "Metro latency from Boston to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
@@ -1387,23 +1042,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.bx_{metroCode}.latency",
-                "description": "Metro latency from Bordeaux to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.ca_{metroCode}.latency",
                 "description": "Metro latency from Canberra to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.ca_{metroCode}.latency",
-                "description": "Metro latency from Canberra to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.ch_{metroCode}.latency",
-                "description": "Metro latency from Chicago to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
@@ -1417,23 +1057,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.cl_{metroCode}.latency",
-                "description": "Metro latency from Calgary to  ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.cu_{metroCode}.latency",
                 "description": "Metro latency from Culpeper to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.cu_{metroCode}.latency",
-                "description": "Metro latency from Culpeper to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.da_{metroCode}.latency",
-                "description": "Metro latency from Dallas to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
@@ -1447,23 +1072,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.db_{metroCode}.latency",
-                "description": "Metro latency from Dublin to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.dc_{metroCode}.latency",
                 "description": "Metro latency from Ashburn to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.dc_{metroCode}.latency",
-                "description": "Metro latency from Ashburn to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.de_{metroCode}.latency",
-                "description": "Metro latency from Denver to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
@@ -1477,23 +1087,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.dx_{metroCode}.latency",
-                "description": "Metro latency from Dubai to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.fr_{metroCode}.latency",
                 "description": "Metro latency from Frankfurt to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.fr_{metroCode}.latency",
-                "description": "Metro latency from Frankfurt to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.gv_{metroCode}.latency",
-                "description": "Metro latency from Geneva to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
@@ -1507,23 +1102,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.he_{metroCode}.latency",
-                "description": "Metro latency from Helsinki to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.hh_{metroCode}.latency",
                 "description": "Metro latency from Hamburg to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.hh_{metroCode}.latency",
-                "description": "Metro latency from Hamburg to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.hk_{metroCode}.latency",
-                "description": "Metro latency from Hong Kong to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
@@ -1537,23 +1117,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.ho_{metroCode}.latency",
-                "description": "Metro latency from Houston to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.il_{metroCode}.latency",
                 "description": "Metro latency from Istanbul to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.il_{metroCode}.latency",
-                "description": "Metro latency from Istanbul to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.jh_{metroCode}.latency",
-                "description": "Metro latency from Johor to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
@@ -1567,23 +1132,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.ka_{metroCode}.latency",
-                "description": "Metro latency from Kamloops to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.kl_{metroCode}.latency",
                 "description": "Metro latency from Kuala Lumpur to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.kl_{metroCode}.latency",
-                "description": "Metro latency from Kuala Lumpur to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.la_{metroCode}.latency",
-                "description": "Metro latency from Los Angeles to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
@@ -1597,23 +1147,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.ld_{metroCode}.latency",
-                "description": "Metro latency from London to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.lm_{metroCode}.latency",
                 "description": "Metro latency from Lima to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.lm_{metroCode}.latency",
-                "description": "Metro latency from Lima to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.ls_{metroCode}.latency",
-                "description": "Metro latency from Lisbon to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
@@ -1627,23 +1162,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.ma_{metroCode}.latency",
-                "description": "Metro latency from Manchester to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.mb_{metroCode}.latency",
                 "description": "Metro latency from Mumbai to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.mb_{metroCode}.latency",
-                "description": "Metro latency from Mumbai to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.md_{metroCode}.latency",
-                "description": "Metro latency from Madrid to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
@@ -1657,23 +1177,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.me_{metroCode}.latency",
-                "description": "Metro latency from Melbourne to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.mi_{metroCode}.latency",
                 "description": "Metro latency from Miami to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.mi_{metroCode}.latency",
-                "description": "Metro latency from Miami to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.ml_{metroCode}.latency",
-                "description": "Metro latency from Milan to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
@@ -1687,23 +1192,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.mo_{metroCode}.latency",
-                "description": "Metro latency from Monterrey to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.mt_{metroCode}.latency",
                 "description": "Metro latency from Montreal to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.mt_{metroCode}.latency",
-                "description": "Metro latency from Montreal to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.mu_{metroCode}.latency",
-                "description": "Metro latency from Munich to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
@@ -1717,23 +1207,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.mx_{metroCode}.latency",
-                "description": "Metro latency from Mexico City to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.ny_{metroCode}.latency",
                 "description": "Metro latency from New York to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.ny_{metroCode}.latency",
-                "description": "Metro latency from New York to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.os_{metroCode}.latency",
-                "description": "Metro latency from Osaka to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
@@ -1747,23 +1222,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.ot_{metroCode}.latency",
-                "description": "Metro latency from Ottawa to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.pa_{metroCode}.latency",
                 "description": "Metro latency from Paris to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.pa_{metroCode}.latency",
-                "description": "Metro latency from Paris to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.pe_{metroCode}.latency",
-                "description": "Metro latency from Perth to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
@@ -1777,23 +1237,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.ph_{metroCode}.latency",
-                "description": "Metro latency from Philadelphia to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.rj_{metroCode}.latency",
                 "description": "Metro latency from Rio de Janeiro to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.rj_{metroCode}.latency",
-                "description": "Metro latency from Rio de Janeiro to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.se_{metroCode}.latency",
-                "description": "Metro latency from Seattle to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
@@ -1807,23 +1252,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.sg_{metroCode}.latency",
-                "description": "Metro latency from Singapore to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.sk_{metroCode}.latency",
                 "description": "Metro latency from Stockholm to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.sk_{metroCode}.latency",
-                "description": "Metro latency from Stockholm to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.sl_{metroCode}.latency",
-                "description": "Metro latency from Seoul to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
@@ -1837,23 +1267,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.so_{metroCode}.latency",
-                "description": "Metro latency from Sofia to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.sp_{metroCode}.latency",
                 "description": "Metro latency from Sao Paulo to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.sp_{metroCode}.latency",
-                "description": "Metro latency from Sao Paulo to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.st_{metroCode}.latency",
-                "description": "Metro latency from Santiago to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
@@ -1867,23 +1282,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.sv_{metroCode}.latency",
-                "description": "Metro latency from Silicon Valley to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.sy_{metroCode}.latency",
                 "description": "Metro latency from Sydney to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.sy_{metroCode}.latency",
-                "description": "Metro latency from Sydney to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.tr_{metroCode}.latency",
-                "description": "Metro latency from Toronto to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {
@@ -1897,16 +1297,6 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.ty_{metroCode}.latency",
-                "description": "Metro latency from Tokyo to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.va_{metroCode}.latency",
-                "description": "Metro latency from Vancouver to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.va_{metroCode}.latency",
                 "description": "Metro latency from Vancouver to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
@@ -1917,23 +1307,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.wa_{metroCode}.latency",
-                "description": "Metro latency from Warsaw to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.wi_{metroCode}.latency",
                 "description": "Metro latency from Winnipeg to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.wi_{metroCode}.latency",
-                "description": "Metro latency from Winnipeg to ${metroCode} above ${threshold}",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.zh_{metroCode}.latency",
-                "description": "Metro latency from Zurich to ${metroCode} above ${threshold}",
                 "releaseStatus": "released"
             },
             {

--- a/README.md
+++ b/README.md
@@ -998,6 +998,18 @@ The following data payloads are the supported events and formats for Equinix Net
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
+		<td>equinix.fabric.metro.jk_{metroCode}.latency</td>
+		<td>Metro latency from Jakarta to ${metroCode} above ${threshold}</td>
+		<td>released</td>
+	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
+	</tr>
+	<tr>
+		<td>equinix.fabric.metro.jn_{metroCode}.latency</td>
+		<td>Metro latency from Johannesburg to ${metroCode} above ${threshold}</td>
+		<td>released</td>
+	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
+	</tr>
+	<tr>
 		<td>equinix.fabric.metro.ka_{metroCode}.latency</td>
 		<td>Metro latency from Kamloops to ${metroCode} above ${threshold}</td>
 		<td>released</td>
@@ -1488,6 +1500,18 @@ The following data payloads are the supported events and formats for Equinix Net
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
+		<td>equinix.fabric.metro.jk_{metroCode}.latency</td>
+		<td>Jakarta to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>released</td>
+	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
+	</tr>
+	<tr>
+		<td>equinix.fabric.metro.jn_{metroCode}.latency</td>
+		<td>Johannesburg to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>released</td>
+	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
+	</tr>
+	<tr>
 		<td>equinix.fabric.metro.ka_{metroCode}.latency</td>
 		<td>Kamloops to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
@@ -1916,6 +1940,18 @@ The following data payloads are the supported events and formats for Equinix Net
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
+		<td>equinix.fabric.metro.jk_{metroCode}.latency</td>
+		<td>Metro latency from Jakarta to ${metroCode} above ${threshold}</td>
+		<td>released</td>
+	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
+	</tr>
+	<tr>
+		<td>equinix.fabric.metro.jn_{metroCode}.latency</td>
+		<td>Metro latency from Johannesburg to ${metroCode} above ${threshold}</td>
+		<td>released</td>
+	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
+	</tr>
+	<tr>
 		<td>equinix.fabric.metro.ka_{metroCode}.latency</td>
 		<td>Metro latency from Kamloops to ${metroCode} above ${threshold}</td>
 		<td>released</td>
@@ -2318,6 +2354,18 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.jh_{metroCode}.latency</td>
 		<td>Johor to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>released</td>
+	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
+	</tr>
+	<tr>
+		<td>equinix.fabric.metro.jk_{metroCode}.latency</td>
+		<td>Jakarta to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>released</td>
+	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
+	</tr>
+	<tr>
+		<td>equinix.fabric.metro.jn_{metroCode}.latency</td>
+		<td>Johannesburg to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>

--- a/README.md
+++ b/README.md
@@ -1292,7 +1292,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	</tr>
 	<tr>
 		<td>equinix.fabric.metric</td>
-		<td></td>
+		<td>Metrics collected</td>
 		<td>-</td>
 	<td>-</td>
 	</tr>

--- a/README.md
+++ b/README.md
@@ -1305,7 +1305,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metric</td>
 		<td>Metrics collected</td>
-		<td>-</td>
+		<td>released</td>
 	<td>-</td>
 	</tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -1774,373 +1774,373 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.am_{metroCode}.latency</td>
 		<td>Metro latency from Amsterdam to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.at_{metroCode}.latency</td>
 		<td>Metro latency from Atlanta to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ba_{metroCode}.latency</td>
 		<td>Metro latency from Barcelona to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.bg_{metroCode}.latency</td>
 		<td>Metro latency from Bogota to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.bl_{metroCode}.latency</td>
 		<td>Metro latency from Brussels to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.bo_{metroCode}.latency</td>
 		<td>Metro latency from Boston to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.bx_{metroCode}.latency</td>
 		<td>Metro latency from Bordeaux to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ca_{metroCode}.latency</td>
 		<td>Metro latency from Canberra to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ch_{metroCode}.latency</td>
 		<td>Metro latency from Chicago to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.cl_{metroCode}.latency</td>
 		<td>Metro latency from Calgary to  ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.cu_{metroCode}.latency</td>
 		<td>Metro latency from Culpeper to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.da_{metroCode}.latency</td>
 		<td>Metro latency from Dallas to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.db_{metroCode}.latency</td>
 		<td>Metro latency from Dublin to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.dc_{metroCode}.latency</td>
 		<td>Metro latency from Ashburn to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.de_{metroCode}.latency</td>
 		<td>Metro latency from Denver to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.dx_{metroCode}.latency</td>
 		<td>Metro latency from Dubai to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.fr_{metroCode}.latency</td>
 		<td>Metro latency from Frankfurt to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.gv_{metroCode}.latency</td>
 		<td>Metro latency from Geneva to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.he_{metroCode}.latency</td>
 		<td>Metro latency from Helsinki to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.hh_{metroCode}.latency</td>
 		<td>Metro latency from Hamburg to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.hk_{metroCode}.latency</td>
 		<td>Metro latency from Hong Kong to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ho_{metroCode}.latency</td>
 		<td>Metro latency from Houston to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.il_{metroCode}.latency</td>
 		<td>Metro latency from Istanbul to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.jh_{metroCode}.latency</td>
 		<td>Metro latency from Johor to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ka_{metroCode}.latency</td>
 		<td>Metro latency from Kamloops to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.kl_{metroCode}.latency</td>
 		<td>Metro latency from Kuala Lumpur to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.la_{metroCode}.latency</td>
 		<td>Metro latency from Los Angeles to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ld_{metroCode}.latency</td>
 		<td>Metro latency from London to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.lm_{metroCode}.latency</td>
 		<td>Metro latency from Lima to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ls_{metroCode}.latency</td>
 		<td>Metro latency from Lisbon to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ma_{metroCode}.latency</td>
 		<td>Metro latency from Manchester to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mb_{metroCode}.latency</td>
 		<td>Metro latency from Mumbai to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.md_{metroCode}.latency</td>
 		<td>Metro latency from Madrid to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.me_{metroCode}.latency</td>
 		<td>Metro latency from Melbourne to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mi_{metroCode}.latency</td>
 		<td>Metro latency from Miami to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ml_{metroCode}.latency</td>
 		<td>Metro latency from Milan to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mo_{metroCode}.latency</td>
 		<td>Metro latency from Monterrey to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mt_{metroCode}.latency</td>
 		<td>Metro latency from Montreal to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mu_{metroCode}.latency</td>
 		<td>Metro latency from Munich to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mx_{metroCode}.latency</td>
 		<td>Metro latency from Mexico City to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ny_{metroCode}.latency</td>
 		<td>Metro latency from New York to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.os_{metroCode}.latency</td>
 		<td>Metro latency from Osaka to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ot_{metroCode}.latency</td>
 		<td>Metro latency from Ottawa to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.pa_{metroCode}.latency</td>
 		<td>Metro latency from Paris to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.pe_{metroCode}.latency</td>
 		<td>Metro latency from Perth to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ph_{metroCode}.latency</td>
 		<td>Metro latency from Philadelphia to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.rj_{metroCode}.latency</td>
 		<td>Metro latency from Rio de Janeiro to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.se_{metroCode}.latency</td>
 		<td>Metro latency from Seattle to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sg_{metroCode}.latency</td>
 		<td>Metro latency from Singapore to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sk_{metroCode}.latency</td>
 		<td>Metro latency from Stockholm to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sl_{metroCode}.latency</td>
 		<td>Metro latency from Seoul to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.so_{metroCode}.latency</td>
 		<td>Metro latency from Sofia to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sp_{metroCode}.latency</td>
 		<td>Metro latency from Sao Paulo to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.st_{metroCode}.latency</td>
 		<td>Metro latency from Santiago to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sv_{metroCode}.latency</td>
 		<td>Metro latency from Silicon Valley to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sy_{metroCode}.latency</td>
 		<td>Metro latency from Sydney to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.tr_{metroCode}.latency</td>
 		<td>Metro latency from Toronto to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ty_{metroCode}.latency</td>
 		<td>Metro latency from Tokyo to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.va_{metroCode}.latency</td>
 		<td>Metro latency from Vancouver to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.wa_{metroCode}.latency</td>
 		<td>Metro latency from Warsaw to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.wi_{metroCode}.latency</td>
 		<td>Metro latency from Winnipeg to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.zh_{metroCode}.latency</td>
 		<td>Metro latency from Zurich to ${metroCode} above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -807,193 +807,193 @@ The following data payloads are the supported events and formats for Equinix Net
 	</tr>
 	<tr>
 		<td>equinix.fabric.connection.bandwidth_rx.usage</td>
-		<td>Connection inbound bandwidth usage above ${threshold}</td>
+		<td>Connection inbound bandwidth usage is ${operator} ${operand} bit/s</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.connection.bandwidth_tx.usage</td>
-		<td>Connection outbound bandwidth usage above ${threshold}</td>
+		<td>Connection outbound bandwidth usage is ${operator} ${operand} bit/s</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.connection.installed_routes_ipv4.utilization</td>
-		<td>Utilization of connection '${connection_name}' active IPv4 routes reached ${threshold}</td>
+		<td>Utilization of connection active IPv4 routes is ${operator} ${operand}</td>
 		<td>released</td>
 	<td><a href='#brown_event_slo'> <span style='color:brown'>BROWN_EVENT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.connection.installed_routes_ipv6.utilization</td>
-		<td>Utilization of connection '${connection_name}' active IPv6 routes reached ${threshold}</td>
+		<td>Utilization of connection active IPv6 routes is ${operator} ${operand}</td>
 		<td>released</td>
 	<td><a href='#brown_event_slo'> <span style='color:brown'>BROWN_EVENT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.connection.packets_dropped_rx_aside_rateexceeded.count</td>
-		<td>Connection A side inbound dropped packets count above ${threshold}</td>
+		<td>Connection A side inbound dropped packets count is ${operator} ${operand}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.connection.packets_dropped_rx_zside_rateexceeded.count</td>
-		<td>Connection Z side inbound dropped packets count above ${threshold}</td>
+		<td>Connection Z side inbound dropped packets count is ${operator} ${operand}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.connection.packets_dropped_tx_aside_rateexceeded.count</td>
-		<td>Connection A side outbound dropped packets count above ${threshold}</td>
+		<td>Connection A side outbound dropped packets count is ${operator} ${operand}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.connection.packets_dropped_tx_zside_rateexceeded.count</td>
-		<td>Connection Z side outbound dropped packets count above ${threshold}</td>
+		<td>Connection Z side outbound dropped packets count is ${operator} ${operand}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.am_{metroCode}.latency</td>
-		<td>Metro latency from Amsterdam to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Amsterdam to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.at_{metroCode}.latency</td>
-		<td>Metro latency from Atlanta to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Atlanta to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ba_{metroCode}.latency</td>
-		<td>Metro latency from Barcelona to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Barcelona to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.bg_{metroCode}.latency</td>
-		<td>Metro latency from Bogota to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Bogota to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.bl_{metroCode}.latency</td>
-		<td>Metro latency from Brussels to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Brussels to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.bo_{metroCode}.latency</td>
-		<td>Metro latency from Boston to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Boston to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.bx_{metroCode}.latency</td>
-		<td>Metro latency from Bordeaux to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Bordeaux to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ca_{metroCode}.latency</td>
-		<td>Metro latency from Canberra to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Canberra to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ch_{metroCode}.latency</td>
-		<td>Metro latency from Chicago to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Chicago to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.cl_{metroCode}.latency</td>
-		<td>Metro latency from Calgary to  ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Calgary to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.cu_{metroCode}.latency</td>
-		<td>Metro latency from Culpeper to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Culpeper to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.da_{metroCode}.latency</td>
-		<td>Metro latency from Dallas to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Dallas to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.db_{metroCode}.latency</td>
-		<td>Metro latency from Dublin to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Dublin to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.dc_{metroCode}.latency</td>
-		<td>Metro latency from Ashburn to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Ashburn to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.de_{metroCode}.latency</td>
-		<td>Metro latency from Denver to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Denver to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.dx_{metroCode}.latency</td>
-		<td>Metro latency from Dubai to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Dubai to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.fr_{metroCode}.latency</td>
-		<td>Metro latency from Frankfurt to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Frankfurt to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.gv_{metroCode}.latency</td>
-		<td>Metro latency from Geneva to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Geneva to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.he_{metroCode}.latency</td>
-		<td>Metro latency from Helsinki to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Helsinki to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.hh_{metroCode}.latency</td>
-		<td>Metro latency from Hamburg to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Hamburg to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.hk_{metroCode}.latency</td>
-		<td>Metro latency from Hong Kong to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Hong Kong to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ho_{metroCode}.latency</td>
-		<td>Metro latency from Houston to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Houston to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.il_{metroCode}.latency</td>
-		<td>Metro latency from Istanbul to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Istanbul to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.jh_{metroCode}.latency</td>
-		<td>Metro latency from Johor to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Johor to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
@@ -1011,277 +1011,277 @@ The following data payloads are the supported events and formats for Equinix Net
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ka_{metroCode}.latency</td>
-		<td>Metro latency from Kamloops to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Kamloops to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.kl_{metroCode}.latency</td>
-		<td>Metro latency from Kuala Lumpur to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Kuala Lumpur to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.la_{metroCode}.latency</td>
-		<td>Metro latency from Los Angeles to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Los Angeles to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ld_{metroCode}.latency</td>
-		<td>Metro latency from London to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from London to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.lm_{metroCode}.latency</td>
-		<td>Metro latency from Lima to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Lima to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ls_{metroCode}.latency</td>
-		<td>Metro latency from Lisbon to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Lisbon to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ma_{metroCode}.latency</td>
-		<td>Metro latency from Manchester to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Manchester to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mb_{metroCode}.latency</td>
-		<td>Metro latency from Mumbai to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Mumbai to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.md_{metroCode}.latency</td>
-		<td>Metro latency from Madrid to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Madrid to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.me_{metroCode}.latency</td>
-		<td>Metro latency from Melbourne to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Melbourne to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mi_{metroCode}.latency</td>
-		<td>Metro latency from Miami to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Miami to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ml_{metroCode}.latency</td>
-		<td>Metro latency from Milan to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Milan to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mo_{metroCode}.latency</td>
-		<td>Metro latency from Monterrey to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Monterrey to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mt_{metroCode}.latency</td>
-		<td>Metro latency from Montreal to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Montreal to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mu_{metroCode}.latency</td>
-		<td>Metro latency from Munich to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Munich to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mx_{metroCode}.latency</td>
-		<td>Metro latency from Mexico City to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Mexico City to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ny_{metroCode}.latency</td>
-		<td>Metro latency from New York to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from New York to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.os_{metroCode}.latency</td>
-		<td>Metro latency from Osaka to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Osaka to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ot_{metroCode}.latency</td>
-		<td>Metro latency from Ottawa to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Ottawa to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.pa_{metroCode}.latency</td>
-		<td>Metro latency from Paris to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Paris to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.pe_{metroCode}.latency</td>
-		<td>Metro latency from Perth to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Perth to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ph_{metroCode}.latency</td>
-		<td>Metro latency from Philadelphia to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Philadelphia to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.rj_{metroCode}.latency</td>
-		<td>Metro latency from Rio de Janeiro to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Rio de Janeiro to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.se_{metroCode}.latency</td>
-		<td>Metro latency from Seattle to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Seattle to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sg_{metroCode}.latency</td>
-		<td>Metro latency from Singapore to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Singapore to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sk_{metroCode}.latency</td>
-		<td>Metro latency from Stockholm to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Stockholm to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sl_{metroCode}.latency</td>
-		<td>Metro latency from Seoul to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Seoul to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.so_{metroCode}.latency</td>
-		<td>Metro latency from Sofia to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Sofia to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sp_{metroCode}.latency</td>
-		<td>Metro latency from Sao Paulo to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Sao Paulo to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.st_{metroCode}.latency</td>
-		<td>Metro latency from Santiago to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Santiago to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sv_{metroCode}.latency</td>
-		<td>Metro latency from Silicon Valley to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Silicon Valley to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sy_{metroCode}.latency</td>
-		<td>Metro latency from Sydney to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Sydney to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.tr_{metroCode}.latency</td>
-		<td>Metro latency from Toronto to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Toronto to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ty_{metroCode}.latency</td>
-		<td>Metro latency from Tokyo to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Tokyo to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.va_{metroCode}.latency</td>
-		<td>Metro latency from Vancouver to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Vancouver to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.wa_{metroCode}.latency</td>
-		<td>Metro latency from Warsaw to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Warsaw to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.wi_{metroCode}.latency</td>
-		<td>Metro latency from Winnipeg to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Winnipeg to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.zh_{metroCode}.latency</td>
-		<td>Metro latency from Zurich to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Zurich to ${metroCode} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.port.bandwidth_rx.usage</td>
-		<td>Port inbound bandwidth usage above ${threshold}</td>
+		<td>Port inbound bandwidth usage is ${operator} ${operand} bit/s</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.port.bandwidth_tx.usage</td>
-		<td>Port outbound bandwidth usage above ${threshold}</td>
+		<td>Port outbound bandwidth usage is ${operator} ${operand} bit/s</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.port.packets_dropped_rx.count</td>
-		<td>Port inbound dropped packets count above ${threshold}</td>
+		<td>Port inbound dropped packets count is ${operator} ${operand}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.port.packets_dropped_tx.count</td>
-		<td>Port outbound dropped packets count above ${threshold}</td>
+		<td>Port outbound dropped packets count is ${operator} ${operand}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.port.packets_erred_rx.count</td>
-		<td>Port inbound erred packets count above ${threshold}</td>
+		<td>Port inbound erred packets count is ${operator} ${operand}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.port.packets_erred_tx.count</td>
-		<td>Port outbound erred packets count above ${threshold}</td>
+		<td>Port outbound erred packets count is ${operator} ${operand}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.router.installed_routes_ipv4.utilization</td>
-		<td>Utilization of router '${router_name}' total IPv4 routes reached ${threshold}</td>
+		<td>Utilization of router total IPv4 routes is ${operator} ${operand}</td>
 		<td>released</td>
 	<td><a href='#brown_event_slo'> <span style='color:brown'>BROWN_EVENT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.router.installed_routes_ipv6.utilization</td>
-		<td>Utilization of router '${router_name}' total IPv6 routes reached ${threshold}</td>
+		<td>Utilization of router total IPv6 routes is ${operator} ${operand}</td>
 		<td>released</td>
 	<td><a href='#brown_event_slo'> <span style='color:brown'>BROWN_EVENT_SLO</span></a></td>
 	</tr>

--- a/README.md
+++ b/README.md
@@ -808,13 +808,13 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.connection.bandwidth_rx.usage</td>
 		<td>Connection inbound bandwidth usage above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.connection.bandwidth_tx.usage</td>
 		<td>Connection outbound bandwidth usage above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -855,410 +855,410 @@ The following data payloads are the supported events and formats for Equinix Net
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.am_{metroCode}.latency</td>
-		<td>Metro latency from AM to ${metroCode} in ms</td>
+		<td>Metro latency from Amsterdam to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.at_{metroCode}.latency</td>
-		<td>Metro latency from AT to ${metroCode} in ms</td>
+		<td>Metro latency from Atlanta to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ba_{metroCode}.latency</td>
-		<td>Metro latency from BA to ${metroCode} in ms</td>
+		<td>Metro latency from Barcelona to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.bg_{metroCode}.latency</td>
-		<td>Metro latency from BG to ${metroCode} in ms</td>
+		<td>Metro latency from Bogota to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.bl_{metroCode}.latency</td>
-		<td>Metro latency from BL to ${metroCode} in ms</td>
+		<td>Metro latency from Brussels to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.bo_{metroCode}.latency</td>
-		<td>Metro latency from BO to ${metroCode} in ms</td>
+		<td>Metro latency from Boston to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.bx_{metroCode}.latency</td>
-		<td>Metro latency from BX to ${metroCode} in ms</td>
+		<td>Metro latency from Bordeaux to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ca_{metroCode}.latency</td>
-		<td>Metro latency from CA to ${metroCode} in ms</td>
+		<td>Metro latency from Canberra to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ch_{metroCode}.latency</td>
-		<td>Metro latency from CH to ${metroCode} in ms</td>
+		<td>Metro latency from Chicago to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.cl_{metroCode}.latency</td>
-		<td>Metro latency from CL to ${metroCode} in ms</td>
+		<td>Metro latency from Calgary to  ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.cu_{metroCode}.latency</td>
-		<td>Metro latency from CU to ${metroCode} in ms</td>
+		<td>Metro latency from Culpeper to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.da_{metroCode}.latency</td>
-		<td>Metro latency from DA to ${metroCode} in ms</td>
+		<td>Metro latency from Dallas to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.db_{metroCode}.latency</td>
-		<td>Metro latency from DB to ${metroCode} in ms</td>
+		<td>Metro latency from Dublin to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.dc_{metroCode}.latency</td>
-		<td>Metro latency from DC to ${metroCode} in ms</td>
+		<td>Metro latency from Ashburn to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.de_{metroCode}.latency</td>
-		<td>Metro latency from DE to ${metroCode} in ms</td>
+		<td>Metro latency from Denver to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.dx_{metroCode}.latency</td>
-		<td>Metro latency from DX to ${metroCode} in ms</td>
+		<td>Metro latency from Dubai to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.fr_{metroCode}.latency</td>
-		<td>Metro latency from FR to ${metroCode} in ms</td>
+		<td>Metro latency from Frankfurt to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.gv_{metroCode}.latency</td>
-		<td>Metro latency from GV to ${metroCode} in ms</td>
+		<td>Metro latency from Geneva to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.he_{metroCode}.latency</td>
-		<td>Metro latency from HE to ${metroCode} in ms</td>
+		<td>Metro latency from Helsinki to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.hh_{metroCode}.latency</td>
-		<td>Metro latency from HH to ${metroCode} in ms</td>
+		<td>Metro latency from Hamburg to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.hk_{metroCode}.latency</td>
-		<td>Metro latency from HK to ${metroCode} in ms</td>
+		<td>Metro latency from Hong Kong to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ho_{metroCode}.latency</td>
-		<td>Metro latency from HO to ${metroCode} in ms</td>
+		<td>Metro latency from Houston to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.il_{metroCode}.latency</td>
-		<td>Metro latency from IL to ${metroCode} in ms</td>
+		<td>Metro latency from Istanbul to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.jh_{metroCode}.latency</td>
-		<td>Metro latency from JH to ${metroCode} in ms</td>
+		<td>Metro latency from Johor to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ka_{metroCode}.latency</td>
-		<td>Metro latency from KA to ${metroCode} in ms</td>
+		<td>Metro latency from Kamloops to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.kl_{metroCode}.latency</td>
-		<td>Metro latency from KL to ${metroCode} in ms</td>
+		<td>Metro latency from Kuala Lumpur to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.la_{metroCode}.latency</td>
-		<td>Metro latency from LA to ${metroCode} in ms</td>
+		<td>Metro latency from Los Angeles to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ld_{metroCode}.latency</td>
-		<td>Metro latency from LD to ${metroCode} in ms</td>
+		<td>Metro latency from London to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.lm_{metroCode}.latency</td>
-		<td>Metro latency from LM to ${metroCode} in ms</td>
+		<td>Metro latency from Lima to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ls_{metroCode}.latency</td>
-		<td>Metro latency from LS to ${metroCode} in ms</td>
+		<td>Metro latency from Lisbon to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ma_{metroCode}.latency</td>
-		<td>Metro latency from MA to ${metroCode} in ms</td>
+		<td>Metro latency from Manchester to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mb_{metroCode}.latency</td>
-		<td>Metro latency from MB to ${metroCode} in ms</td>
+		<td>Metro latency from Mumbai to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.md_{metroCode}.latency</td>
-		<td>Metro latency from MD to ${metroCode} in ms</td>
+		<td>Metro latency from Madrid to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.me_{metroCode}.latency</td>
-		<td>Metro latency from ME to ${metroCode} in ms</td>
+		<td>Metro latency from Melbourne to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mi_{metroCode}.latency</td>
-		<td>Metro latency from MI to ${metroCode} in ms</td>
+		<td>Metro latency from Miami to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ml_{metroCode}.latency</td>
-		<td>Metro latency from ML to ${metroCode} in ms</td>
+		<td>Metro latency from Milan to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mo_{metroCode}.latency</td>
-		<td>Metro latency from MO to ${metroCode} in ms</td>
+		<td>Metro latency from Monterrey to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mt_{metroCode}.latency</td>
-		<td>Metro latency from MT to ${metroCode} in ms</td>
+		<td>Metro latency from Montreal to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mu_{metroCode}.latency</td>
-		<td>Metro latency from MU to ${metroCode} in ms</td>
+		<td>Metro latency from Munich to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mx_{metroCode}.latency</td>
-		<td>Metro latency from MX to ${metroCode} in ms</td>
+		<td>Metro latency from Mexico City to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ny_{metroCode}.latency</td>
-		<td>Metro latency from NY to ${metroCode} in ms</td>
+		<td>Metro latency from New York to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.os_{metroCode}.latency</td>
-		<td>Metro latency from OS to ${metroCode} in ms</td>
+		<td>Metro latency from Osaka to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ot_{metroCode}.latency</td>
-		<td>Metro latency from OT to ${metroCode} in ms</td>
+		<td>Metro latency from Ottawa to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.pa_{metroCode}.latency</td>
-		<td>Metro latency from PA to ${metroCode} in ms</td>
+		<td>Metro latency from Paris to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.pe_{metroCode}.latency</td>
-		<td>Metro latency from PE to ${metroCode} in ms</td>
+		<td>Metro latency from Perth to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ph_{metroCode}.latency</td>
-		<td>Metro latency from PH to ${metroCode} in ms</td>
+		<td>Metro latency from Philadelphia to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.rj_{metroCode}.latency</td>
-		<td>Metro latency from RJ to ${metroCode} in ms</td>
+		<td>Metro latency from Rio de Janeiro to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.se_{metroCode}.latency</td>
-		<td>Metro latency from SE to ${metroCode} in ms</td>
+		<td>Metro latency from Seattle to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sg_{metroCode}.latency</td>
-		<td>Metro latency from SG to ${metroCode} in ms</td>
+		<td>Metro latency from Singapore to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sk_{metroCode}.latency</td>
-		<td>Metro latency from SK to ${metroCode} in ms</td>
+		<td>Metro latency from Stockholm to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sl_{metroCode}.latency</td>
-		<td>Metro latency from SL to ${metroCode} in ms</td>
+		<td>Metro latency from Seoul to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.so_{metroCode}.latency</td>
-		<td>Metro latency from SO to ${metroCode} in ms</td>
+		<td>Metro latency from Sofia to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sp_{metroCode}.latency</td>
-		<td>Metro latency from SP to ${metroCode} in ms</td>
+		<td>Metro latency from Sao Paulo to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.st_{metroCode}.latency</td>
-		<td>Metro latency from ST to ${metroCode} in ms</td>
+		<td>Metro latency from Santiago to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sv_{metroCode}.latency</td>
-		<td>Metro latency from SV to ${metroCode} in ms</td>
+		<td>Metro latency from Silicon Valley to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sy_{metroCode}.latency</td>
-		<td>Metro latency from SY to ${metroCode} in ms</td>
+		<td>Metro latency from Sydney to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.tr_{metroCode}.latency</td>
-		<td>Metro latency from TR to ${metroCode} in ms</td>
+		<td>Metro latency from Toronto to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ty_{metroCode}.latency</td>
-		<td>Metro latency from TY to ${metroCode} in ms</td>
+		<td>Metro latency from Tokyo to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.va_{metroCode}.latency</td>
-		<td>Metro latency from VA to ${metroCode} in ms</td>
+		<td>Metro latency from Vancouver to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.wa_{metroCode}.latency</td>
-		<td>Metro latency from WA to ${metroCode} in ms</td>
+		<td>Metro latency from Warsaw to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.wi_{metroCode}.latency</td>
-		<td>Metro latency from WI to ${metroCode} in ms</td>
+		<td>Metro latency from Winnipeg to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.zh_{metroCode}.latency</td>
-		<td>Metro latency from ZH to ${metroCode} in ms</td>
+		<td>Metro latency from Zurich to ${metroCode} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.port.bandwidth_rx.usage</td>
 		<td>Port inbound bandwidth usage above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.port.bandwidth_tx.usage</td>
 		<td>Port outbound bandwidth usage above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.port.packets_dropped_rx.count</td>
 		<td>Port inbound dropped packets count above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.port.packets_dropped_tx.count</td>
 		<td>Port outbound dropped packets count above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.port.packets_erred_rx.count</td>
 		<td>Port inbound erred packets count above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.port.packets_erred_tx.count</td>
 		<td>Port outbound erred packets count above ${threshold}</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1345,373 +1345,373 @@ The following data payloads are the supported events and formats for Equinix Net
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.am_{metroCode}.latency</td>
-		<td>Metro latency from AM to ${metroCode} in ms</td>
+		<td>Amsterdam to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.at_{metroCode}.latency</td>
-		<td>Metro latency from AT to ${metroCode} in ms</td>
+		<td>Atlanta to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ba_{metroCode}.latency</td>
-		<td>Metro latency from BA to ${metroCode} in ms</td>
+		<td>Barcelona to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.bg_{metroCode}.latency</td>
-		<td>Metro latency from BG to ${metroCode} in ms</td>
+		<td>Bogota to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.bl_{metroCode}.latency</td>
-		<td>Metro latency from BL to ${metroCode} in ms</td>
+		<td>Brussels to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.bo_{metroCode}.latency</td>
-		<td>Metro latency from BO to ${metroCode} in ms</td>
+		<td>Boston to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.bx_{metroCode}.latency</td>
-		<td>Metro latency from BX to ${metroCode} in ms</td>
+		<td>Bordeaux to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ca_{metroCode}.latency</td>
-		<td>Metro latency from CA to ${metroCode} in ms</td>
+		<td>Canberra to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ch_{metroCode}.latency</td>
-		<td>Metro latency from CH to ${metroCode} in ms</td>
+		<td>Chicago to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.cl_{metroCode}.latency</td>
-		<td>Metro latency from CL to ${metroCode} in ms</td>
+		<td>Calgary to  ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.cu_{metroCode}.latency</td>
-		<td>Metro latency from CU to ${metroCode} in ms</td>
+		<td>Culpeper to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.da_{metroCode}.latency</td>
-		<td>Metro latency from DA to ${metroCode} in ms</td>
+		<td>Dallas to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.db_{metroCode}.latency</td>
-		<td>Metro latency from DB to ${metroCode} in ms</td>
+		<td>Dublin to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.dc_{metroCode}.latency</td>
-		<td>Metro latency from DC to ${metroCode} in ms</td>
+		<td>Ashburn to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.de_{metroCode}.latency</td>
-		<td>Metro latency from DE to ${metroCode} in ms</td>
+		<td>Denver to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.dx_{metroCode}.latency</td>
-		<td>Metro latency from DX to ${metroCode} in ms</td>
+		<td>Dubai to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.fr_{metroCode}.latency</td>
-		<td>Metro latency from FR to ${metroCode} in ms</td>
+		<td>Frankfurt to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.gv_{metroCode}.latency</td>
-		<td>Metro latency from GV to ${metroCode} in ms</td>
+		<td>Geneva to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.he_{metroCode}.latency</td>
-		<td>Metro latency from HE to ${metroCode} in ms</td>
+		<td>Helsinki to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.hh_{metroCode}.latency</td>
-		<td>Metro latency from HH to ${metroCode} in ms</td>
+		<td>Hamburg to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.hk_{metroCode}.latency</td>
-		<td>Metro latency from HK to ${metroCode} in ms</td>
+		<td>Hong Kong to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ho_{metroCode}.latency</td>
-		<td>Metro latency from HO to ${metroCode} in ms</td>
+		<td>Houston to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.il_{metroCode}.latency</td>
-		<td>Metro latency from IL to ${metroCode} in ms</td>
+		<td>Istanbul to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.jh_{metroCode}.latency</td>
-		<td>Metro latency from JH to ${metroCode} in ms</td>
+		<td>Johor to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ka_{metroCode}.latency</td>
-		<td>Metro latency from KA to ${metroCode} in ms</td>
+		<td>Kamloops to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.kl_{metroCode}.latency</td>
-		<td>Metro latency from KL to ${metroCode} in ms</td>
+		<td>Kuala Lumpur to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.la_{metroCode}.latency</td>
-		<td>Metro latency from LA to ${metroCode} in ms</td>
+		<td>Los Angeles to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ld_{metroCode}.latency</td>
-		<td>Metro latency from LD to ${metroCode} in ms</td>
+		<td>London to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.lm_{metroCode}.latency</td>
-		<td>Metro latency from LM to ${metroCode} in ms</td>
+		<td>Lima to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ls_{metroCode}.latency</td>
-		<td>Metro latency from LS to ${metroCode} in ms</td>
+		<td>Lisbon to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ma_{metroCode}.latency</td>
-		<td>Metro latency from MA to ${metroCode} in ms</td>
+		<td>Manchester to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mb_{metroCode}.latency</td>
-		<td>Metro latency from MB to ${metroCode} in ms</td>
+		<td>Mumbai to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.md_{metroCode}.latency</td>
-		<td>Metro latency from MD to ${metroCode} in ms</td>
+		<td>Madrid to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.me_{metroCode}.latency</td>
-		<td>Metro latency from ME to ${metroCode} in ms</td>
+		<td>Melbourne to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mi_{metroCode}.latency</td>
-		<td>Metro latency from MI to ${metroCode} in ms</td>
+		<td>Miami to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ml_{metroCode}.latency</td>
-		<td>Metro latency from ML to ${metroCode} in ms</td>
+		<td>Milan to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mo_{metroCode}.latency</td>
-		<td>Metro latency from MO to ${metroCode} in ms</td>
+		<td>Monterrey to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mt_{metroCode}.latency</td>
-		<td>Metro latency from MT to ${metroCode} in ms</td>
+		<td>Montreal to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mu_{metroCode}.latency</td>
-		<td>Metro latency from MU to ${metroCode} in ms</td>
+		<td>Munich to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mx_{metroCode}.latency</td>
-		<td>Metro latency from MX to ${metroCode} in ms</td>
+		<td>Mexico City to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ny_{metroCode}.latency</td>
-		<td>Metro latency from NY to ${metroCode} in ms</td>
+		<td>New York to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.os_{metroCode}.latency</td>
-		<td>Metro latency from OS to ${metroCode} in ms</td>
+		<td>Osaka to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ot_{metroCode}.latency</td>
-		<td>Metro latency from OT to ${metroCode} in ms</td>
+		<td>Ottawa to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.pa_{metroCode}.latency</td>
-		<td>Metro latency from PA to ${metroCode} in ms</td>
+		<td>Paris to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.pe_{metroCode}.latency</td>
-		<td>Metro latency from PE to ${metroCode} in ms</td>
+		<td>Perth to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ph_{metroCode}.latency</td>
-		<td>Metro latency from PH to ${metroCode} in ms</td>
+		<td>Philadelphia to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.rj_{metroCode}.latency</td>
-		<td>Metro latency from RJ to ${metroCode} in ms</td>
+		<td>Rio de Janeiro to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.se_{metroCode}.latency</td>
-		<td>Metro latency from SE to ${metroCode} in ms</td>
+		<td>Seattle to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sg_{metroCode}.latency</td>
-		<td>Metro latency from SG to ${metroCode} in ms</td>
+		<td>Singapore to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sk_{metroCode}.latency</td>
-		<td>Metro latency from SK to ${metroCode} in ms</td>
+		<td>Stockholm to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sl_{metroCode}.latency</td>
-		<td>Metro latency from SL to ${metroCode} in ms</td>
+		<td>Seoul to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.so_{metroCode}.latency</td>
-		<td>Metro latency from SO to ${metroCode} in ms</td>
+		<td>Sofia to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sp_{metroCode}.latency</td>
-		<td>Metro latency from SP to ${metroCode} in ms</td>
+		<td>Sao Paulo to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.st_{metroCode}.latency</td>
-		<td>Metro latency from ST to ${metroCode} in ms</td>
+		<td>Santiago to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sv_{metroCode}.latency</td>
-		<td>Metro latency from SV to ${metroCode} in ms</td>
+		<td>Silicon Valley to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sy_{metroCode}.latency</td>
-		<td>Metro latency from SY to ${metroCode} in ms</td>
+		<td>Sydney to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.tr_{metroCode}.latency</td>
-		<td>Metro latency from TR to ${metroCode} in ms</td>
+		<td>Toronto to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ty_{metroCode}.latency</td>
-		<td>Metro latency from TY to ${metroCode} in ms</td>
+		<td>Tokyo to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.va_{metroCode}.latency</td>
-		<td>Metro latency from VA to ${metroCode} in ms</td>
+		<td>Vancouver to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.wa_{metroCode}.latency</td>
-		<td>Metro latency from WA to ${metroCode} in ms</td>
+		<td>Warsaw to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.wi_{metroCode}.latency</td>
-		<td>Metro latency from WI to ${metroCode} in ms</td>
+		<td>Winnipeg to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.zh_{metroCode}.latency</td>
-		<td>Metro latency from ZH to ${metroCode} in ms</td>
+		<td>Zurich to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
@@ -1760,7 +1760,9 @@ The following data payloads are the supported events and formats for Equinix Net
 #### Data Type
 `equinix.fabric.v1.MetroLatencyAlert`
 #### Supported Events, Metrics, and Alerts
-#### Events
+
+
+#### Alerts
 
 <table>
 	<tr>
@@ -1771,379 +1773,377 @@ The following data payloads are the supported events and formats for Equinix Net
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.am_{metroCode}.latency</td>
-		<td>Metro latency from AM to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Amsterdam to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.at_{metroCode}.latency</td>
-		<td>Metro latency from AT to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Atlanta to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ba_{metroCode}.latency</td>
-		<td>Metro latency from BA to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Barcelona to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.bg_{metroCode}.latency</td>
-		<td>Metro latency from BG to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Bogota to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.bl_{metroCode}.latency</td>
-		<td>Metro latency from BL to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Brussels to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.bo_{metroCode}.latency</td>
-		<td>Metro latency from BO to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Boston to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.bx_{metroCode}.latency</td>
-		<td>Metro latency from BX to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Bordeaux to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ca_{metroCode}.latency</td>
-		<td>Metro latency from CA to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Canberra to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ch_{metroCode}.latency</td>
-		<td>Metro latency from CH to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Chicago to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.cl_{metroCode}.latency</td>
-		<td>Metro latency from CL to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Calgary to  ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.cu_{metroCode}.latency</td>
-		<td>Metro latency from CU to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Culpeper to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.da_{metroCode}.latency</td>
-		<td>Metro latency from DA to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Dallas to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.db_{metroCode}.latency</td>
-		<td>Metro latency from DB to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Dublin to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.dc_{metroCode}.latency</td>
-		<td>Metro latency from DC to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Ashburn to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.de_{metroCode}.latency</td>
-		<td>Metro latency from DE to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Denver to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.dx_{metroCode}.latency</td>
-		<td>Metro latency from DX to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Dubai to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.fr_{metroCode}.latency</td>
-		<td>Metro latency from FR to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Frankfurt to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.gv_{metroCode}.latency</td>
-		<td>Metro latency from GV to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Geneva to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.he_{metroCode}.latency</td>
-		<td>Metro latency from HE to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Helsinki to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.hh_{metroCode}.latency</td>
-		<td>Metro latency from HH to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Hamburg to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.hk_{metroCode}.latency</td>
-		<td>Metro latency from HK to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Hong Kong to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ho_{metroCode}.latency</td>
-		<td>Metro latency from HO to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Houston to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.il_{metroCode}.latency</td>
-		<td>Metro latency from IL to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Istanbul to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.jh_{metroCode}.latency</td>
-		<td>Metro latency from JH to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Johor to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ka_{metroCode}.latency</td>
-		<td>Metro latency from KA to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Kamloops to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.kl_{metroCode}.latency</td>
-		<td>Metro latency from KL to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Kuala Lumpur to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.la_{metroCode}.latency</td>
-		<td>Metro latency from LA to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Los Angeles to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ld_{metroCode}.latency</td>
-		<td>Metro latency from LD to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from London to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.lm_{metroCode}.latency</td>
-		<td>Metro latency from LM to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Lima to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ls_{metroCode}.latency</td>
-		<td>Metro latency from LS to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Lisbon to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ma_{metroCode}.latency</td>
-		<td>Metro latency from MA to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Manchester to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mb_{metroCode}.latency</td>
-		<td>Metro latency from MB to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Mumbai to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.md_{metroCode}.latency</td>
-		<td>Metro latency from MD to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Madrid to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.me_{metroCode}.latency</td>
-		<td>Metro latency from ME to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Melbourne to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mi_{metroCode}.latency</td>
-		<td>Metro latency from MI to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Miami to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ml_{metroCode}.latency</td>
-		<td>Metro latency from ML to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Milan to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mo_{metroCode}.latency</td>
-		<td>Metro latency from MO to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Monterrey to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mt_{metroCode}.latency</td>
-		<td>Metro latency from MT to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Montreal to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mu_{metroCode}.latency</td>
-		<td>Metro latency from MU to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Munich to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mx_{metroCode}.latency</td>
-		<td>Metro latency from MX to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Mexico City to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ny_{metroCode}.latency</td>
-		<td>Metro latency from NY to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from New York to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.os_{metroCode}.latency</td>
-		<td>Metro latency from OS to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Osaka to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ot_{metroCode}.latency</td>
-		<td>Metro latency from OT to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Ottawa to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.pa_{metroCode}.latency</td>
-		<td>Metro latency from PA to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Paris to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.pe_{metroCode}.latency</td>
-		<td>Metro latency from PE to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Perth to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ph_{metroCode}.latency</td>
-		<td>Metro latency from PH to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Philadelphia to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.rj_{metroCode}.latency</td>
-		<td>Metro latency from RJ to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Rio de Janeiro to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.se_{metroCode}.latency</td>
-		<td>Metro latency from SE to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Seattle to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sg_{metroCode}.latency</td>
-		<td>Metro latency from SG to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Singapore to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sk_{metroCode}.latency</td>
-		<td>Metro latency from SK to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Stockholm to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sl_{metroCode}.latency</td>
-		<td>Metro latency from SL to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Seoul to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.so_{metroCode}.latency</td>
-		<td>Metro latency from SO to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Sofia to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sp_{metroCode}.latency</td>
-		<td>Metro latency from SP to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Sao Paulo to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.st_{metroCode}.latency</td>
-		<td>Metro latency from ST to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Santiago to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sv_{metroCode}.latency</td>
-		<td>Metro latency from SV to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Silicon Valley to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sy_{metroCode}.latency</td>
-		<td>Metro latency from SY to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Sydney to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.tr_{metroCode}.latency</td>
-		<td>Metro latency from TR to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Toronto to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ty_{metroCode}.latency</td>
-		<td>Metro latency from TY to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Tokyo to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.va_{metroCode}.latency</td>
-		<td>Metro latency from VA to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Vancouver to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.wa_{metroCode}.latency</td>
-		<td>Metro latency from WA to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Warsaw to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.wi_{metroCode}.latency</td>
-		<td>Metro latency from WI to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Winnipeg to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.zh_{metroCode}.latency</td>
-		<td>Metro latency from ZH to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Zurich to ${metroCode} above ${threshold}</td>
 		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 </table>
-
-
 
 ---
 ### Equinix Fabric Metro Latency Metric (Deprecated)
@@ -2179,373 +2179,373 @@ The following data payloads are the supported events and formats for Equinix Net
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.am_{metroCode}.latency</td>
-		<td>Metro latency from AM to ${metroCode} in ms</td>
+		<td>Amsterdam to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.at_{metroCode}.latency</td>
-		<td>Metro latency from AT to ${metroCode} in ms</td>
+		<td>Atlanta to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ba_{metroCode}.latency</td>
-		<td>Metro latency from BA to ${metroCode} in ms</td>
+		<td>Barcelona to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.bg_{metroCode}.latency</td>
-		<td>Metro latency from BG to ${metroCode} in ms</td>
+		<td>Bogota to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.bl_{metroCode}.latency</td>
-		<td>Metro latency from BL to ${metroCode} in ms</td>
+		<td>Brussels to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.bo_{metroCode}.latency</td>
-		<td>Metro latency from BO to ${metroCode} in ms</td>
+		<td>Boston to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.bx_{metroCode}.latency</td>
-		<td>Metro latency from BX to ${metroCode} in ms</td>
+		<td>Bordeaux to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ca_{metroCode}.latency</td>
-		<td>Metro latency from CA to ${metroCode} in ms</td>
+		<td>Canberra to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ch_{metroCode}.latency</td>
-		<td>Metro latency from CH to ${metroCode} in ms</td>
+		<td>Chicago to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.cl_{metroCode}.latency</td>
-		<td>Metro latency from CL to ${metroCode} in ms</td>
+		<td>Calgary to  ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.cu_{metroCode}.latency</td>
-		<td>Metro latency from CU to ${metroCode} in ms</td>
+		<td>Culpeper to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.da_{metroCode}.latency</td>
-		<td>Metro latency from DA to ${metroCode} in ms</td>
+		<td>Dallas to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.db_{metroCode}.latency</td>
-		<td>Metro latency from DB to ${metroCode} in ms</td>
+		<td>Dublin to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.dc_{metroCode}.latency</td>
-		<td>Metro latency from DC to ${metroCode} in ms</td>
+		<td>Ashburn to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.de_{metroCode}.latency</td>
-		<td>Metro latency from DE to ${metroCode} in ms</td>
+		<td>Denver to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.dx_{metroCode}.latency</td>
-		<td>Metro latency from DX to ${metroCode} in ms</td>
+		<td>Dubai to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.fr_{metroCode}.latency</td>
-		<td>Metro latency from FR to ${metroCode} in ms</td>
+		<td>Frankfurt to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.gv_{metroCode}.latency</td>
-		<td>Metro latency from GV to ${metroCode} in ms</td>
+		<td>Geneva to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.he_{metroCode}.latency</td>
-		<td>Metro latency from HE to ${metroCode} in ms</td>
+		<td>Helsinki to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.hh_{metroCode}.latency</td>
-		<td>Metro latency from HH to ${metroCode} in ms</td>
+		<td>Hamburg to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.hk_{metroCode}.latency</td>
-		<td>Metro latency from HK to ${metroCode} in ms</td>
+		<td>Hong Kong to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ho_{metroCode}.latency</td>
-		<td>Metro latency from HO to ${metroCode} in ms</td>
+		<td>Houston to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.il_{metroCode}.latency</td>
-		<td>Metro latency from IL to ${metroCode} in ms</td>
+		<td>Istanbul to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.jh_{metroCode}.latency</td>
-		<td>Metro latency from JH to ${metroCode} in ms</td>
+		<td>Johor to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ka_{metroCode}.latency</td>
-		<td>Metro latency from KA to ${metroCode} in ms</td>
+		<td>Kamloops to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.kl_{metroCode}.latency</td>
-		<td>Metro latency from KL to ${metroCode} in ms</td>
+		<td>Kuala Lumpur to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.la_{metroCode}.latency</td>
-		<td>Metro latency from LA to ${metroCode} in ms</td>
+		<td>Los Angeles to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ld_{metroCode}.latency</td>
-		<td>Metro latency from LD to ${metroCode} in ms</td>
+		<td>London to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.lm_{metroCode}.latency</td>
-		<td>Metro latency from LM to ${metroCode} in ms</td>
+		<td>Lima to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ls_{metroCode}.latency</td>
-		<td>Metro latency from LS to ${metroCode} in ms</td>
+		<td>Lisbon to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ma_{metroCode}.latency</td>
-		<td>Metro latency from MA to ${metroCode} in ms</td>
+		<td>Manchester to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mb_{metroCode}.latency</td>
-		<td>Metro latency from MB to ${metroCode} in ms</td>
+		<td>Mumbai to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.md_{metroCode}.latency</td>
-		<td>Metro latency from MD to ${metroCode} in ms</td>
+		<td>Madrid to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.me_{metroCode}.latency</td>
-		<td>Metro latency from ME to ${metroCode} in ms</td>
+		<td>Melbourne to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mi_{metroCode}.latency</td>
-		<td>Metro latency from MI to ${metroCode} in ms</td>
+		<td>Miami to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ml_{metroCode}.latency</td>
-		<td>Metro latency from ML to ${metroCode} in ms</td>
+		<td>Milan to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mo_{metroCode}.latency</td>
-		<td>Metro latency from MO to ${metroCode} in ms</td>
+		<td>Monterrey to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mt_{metroCode}.latency</td>
-		<td>Metro latency from MT to ${metroCode} in ms</td>
+		<td>Montreal to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mu_{metroCode}.latency</td>
-		<td>Metro latency from MU to ${metroCode} in ms</td>
+		<td>Munich to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mx_{metroCode}.latency</td>
-		<td>Metro latency from MX to ${metroCode} in ms</td>
+		<td>Mexico City to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ny_{metroCode}.latency</td>
-		<td>Metro latency from NY to ${metroCode} in ms</td>
+		<td>New York to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.os_{metroCode}.latency</td>
-		<td>Metro latency from OS to ${metroCode} in ms</td>
+		<td>Osaka to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ot_{metroCode}.latency</td>
-		<td>Metro latency from OT to ${metroCode} in ms</td>
+		<td>Ottawa to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.pa_{metroCode}.latency</td>
-		<td>Metro latency from PA to ${metroCode} in ms</td>
+		<td>Paris to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.pe_{metroCode}.latency</td>
-		<td>Metro latency from PE to ${metroCode} in ms</td>
+		<td>Perth to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ph_{metroCode}.latency</td>
-		<td>Metro latency from PH to ${metroCode} in ms</td>
+		<td>Philadelphia to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.rj_{metroCode}.latency</td>
-		<td>Metro latency from RJ to ${metroCode} in ms</td>
+		<td>Rio de Janeiro to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.se_{metroCode}.latency</td>
-		<td>Metro latency from SE to ${metroCode} in ms</td>
+		<td>Seattle to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sg_{metroCode}.latency</td>
-		<td>Metro latency from SG to ${metroCode} in ms</td>
+		<td>Singapore to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sk_{metroCode}.latency</td>
-		<td>Metro latency from SK to ${metroCode} in ms</td>
+		<td>Stockholm to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sl_{metroCode}.latency</td>
-		<td>Metro latency from SL to ${metroCode} in ms</td>
+		<td>Seoul to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.so_{metroCode}.latency</td>
-		<td>Metro latency from SO to ${metroCode} in ms</td>
+		<td>Sofia to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sp_{metroCode}.latency</td>
-		<td>Metro latency from SP to ${metroCode} in ms</td>
+		<td>Sao Paulo to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.st_{metroCode}.latency</td>
-		<td>Metro latency from ST to ${metroCode} in ms</td>
+		<td>Santiago to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sv_{metroCode}.latency</td>
-		<td>Metro latency from SV to ${metroCode} in ms</td>
+		<td>Silicon Valley to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sy_{metroCode}.latency</td>
-		<td>Metro latency from SY to ${metroCode} in ms</td>
+		<td>Sydney to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.tr_{metroCode}.latency</td>
-		<td>Metro latency from TR to ${metroCode} in ms</td>
+		<td>Toronto to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ty_{metroCode}.latency</td>
-		<td>Metro latency from TY to ${metroCode} in ms</td>
+		<td>Tokyo to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.va_{metroCode}.latency</td>
-		<td>Metro latency from VA to ${metroCode} in ms</td>
+		<td>Vancouver to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.wa_{metroCode}.latency</td>
-		<td>Metro latency from WA to ${metroCode} in ms</td>
+		<td>Warsaw to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.wi_{metroCode}.latency</td>
-		<td>Metro latency from WI to ${metroCode} in ms</td>
+		<td>Winnipeg to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.zh_{metroCode}.latency</td>
-		<td>Metro latency from ZH to ${metroCode} in ms</td>
+		<td>Zurich to ${metroCode} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>

--- a/README.md
+++ b/README.md
@@ -2649,13 +2649,13 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.identity.organization.user.added</td>
 		<td>User added to org event</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.identity.organization.user.removed</td>
 		<td>User removed from org event</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
 	</tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -855,385 +855,385 @@ The following data payloads are the supported events and formats for Equinix Net
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.am_{metroCode}.latency</td>
-		<td>Metro latency from Amsterdam to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Amsterdam to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.at_{metroCode}.latency</td>
-		<td>Metro latency from Atlanta to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Atlanta to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ba_{metroCode}.latency</td>
-		<td>Metro latency from Barcelona to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Barcelona to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.bg_{metroCode}.latency</td>
-		<td>Metro latency from Bogota to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Bogota to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.bl_{metroCode}.latency</td>
-		<td>Metro latency from Brussels to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Brussels to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.bo_{metroCode}.latency</td>
-		<td>Metro latency from Boston to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Boston to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.bx_{metroCode}.latency</td>
-		<td>Metro latency from Bordeaux to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Bordeaux to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ca_{metroCode}.latency</td>
-		<td>Metro latency from Canberra to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Canberra to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ch_{metroCode}.latency</td>
-		<td>Metro latency from Chicago to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Chicago to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.cl_{metroCode}.latency</td>
-		<td>Metro latency from Calgary to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Calgary to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.cu_{metroCode}.latency</td>
-		<td>Metro latency from Culpeper to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Culpeper to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.da_{metroCode}.latency</td>
-		<td>Metro latency from Dallas to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Dallas to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.db_{metroCode}.latency</td>
-		<td>Metro latency from Dublin to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Dublin to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.dc_{metroCode}.latency</td>
-		<td>Metro latency from Ashburn to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Ashburn to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.de_{metroCode}.latency</td>
-		<td>Metro latency from Denver to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Denver to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.dx_{metroCode}.latency</td>
-		<td>Metro latency from Dubai to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Dubai to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.fr_{metroCode}.latency</td>
-		<td>Metro latency from Frankfurt to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Frankfurt to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.gv_{metroCode}.latency</td>
-		<td>Metro latency from Geneva to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Geneva to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.he_{metroCode}.latency</td>
-		<td>Metro latency from Helsinki to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Helsinki to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.hh_{metroCode}.latency</td>
-		<td>Metro latency from Hamburg to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Hamburg to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.hk_{metroCode}.latency</td>
-		<td>Metro latency from Hong Kong to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Hong Kong to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ho_{metroCode}.latency</td>
-		<td>Metro latency from Houston to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Houston to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.il_{metroCode}.latency</td>
-		<td>Metro latency from Istanbul to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Istanbul to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.jh_{metroCode}.latency</td>
-		<td>Metro latency from Johor to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Johor to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.jk_{metroCode}.latency</td>
-		<td>Metro latency from Jakarta to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Jakarta to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.jn_{metroCode}.latency</td>
-		<td>Metro latency from Johannesburg to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Johannesburg to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ka_{metroCode}.latency</td>
-		<td>Metro latency from Kamloops to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Kamloops to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.kl_{metroCode}.latency</td>
-		<td>Metro latency from Kuala Lumpur to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Kuala Lumpur to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.la_{metroCode}.latency</td>
-		<td>Metro latency from Los Angeles to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Los Angeles to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ld_{metroCode}.latency</td>
-		<td>Metro latency from London to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from London to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.lm_{metroCode}.latency</td>
-		<td>Metro latency from Lima to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Lima to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ls_{metroCode}.latency</td>
-		<td>Metro latency from Lisbon to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Lisbon to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ma_{metroCode}.latency</td>
-		<td>Metro latency from Manchester to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Manchester to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mb_{metroCode}.latency</td>
-		<td>Metro latency from Mumbai to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Mumbai to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.md_{metroCode}.latency</td>
-		<td>Metro latency from Madrid to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Madrid to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.me_{metroCode}.latency</td>
-		<td>Metro latency from Melbourne to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Melbourne to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mi_{metroCode}.latency</td>
-		<td>Metro latency from Miami to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Miami to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ml_{metroCode}.latency</td>
-		<td>Metro latency from Milan to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Milan to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mo_{metroCode}.latency</td>
-		<td>Metro latency from Monterrey to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Monterrey to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mt_{metroCode}.latency</td>
-		<td>Metro latency from Montreal to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Montreal to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mu_{metroCode}.latency</td>
-		<td>Metro latency from Munich to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Munich to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mx_{metroCode}.latency</td>
-		<td>Metro latency from Mexico City to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Mexico City to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ny_{metroCode}.latency</td>
-		<td>Metro latency from New York to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from New York to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.os_{metroCode}.latency</td>
-		<td>Metro latency from Osaka to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Osaka to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ot_{metroCode}.latency</td>
-		<td>Metro latency from Ottawa to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Ottawa to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.pa_{metroCode}.latency</td>
-		<td>Metro latency from Paris to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Paris to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.pe_{metroCode}.latency</td>
-		<td>Metro latency from Perth to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Perth to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ph_{metroCode}.latency</td>
-		<td>Metro latency from Philadelphia to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Philadelphia to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.rj_{metroCode}.latency</td>
-		<td>Metro latency from Rio de Janeiro to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Rio de Janeiro to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.se_{metroCode}.latency</td>
-		<td>Metro latency from Seattle to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Seattle to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sg_{metroCode}.latency</td>
-		<td>Metro latency from Singapore to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Singapore to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sk_{metroCode}.latency</td>
-		<td>Metro latency from Stockholm to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Stockholm to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sl_{metroCode}.latency</td>
-		<td>Metro latency from Seoul to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Seoul to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.so_{metroCode}.latency</td>
-		<td>Metro latency from Sofia to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Sofia to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sp_{metroCode}.latency</td>
-		<td>Metro latency from Sao Paulo to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Sao Paulo to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.st_{metroCode}.latency</td>
-		<td>Metro latency from Santiago to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Santiago to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sv_{metroCode}.latency</td>
-		<td>Metro latency from Silicon Valley to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Silicon Valley to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sy_{metroCode}.latency</td>
-		<td>Metro latency from Sydney to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Sydney to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.tr_{metroCode}.latency</td>
-		<td>Metro latency from Toronto to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Toronto to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ty_{metroCode}.latency</td>
-		<td>Metro latency from Tokyo to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Tokyo to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.va_{metroCode}.latency</td>
-		<td>Metro latency from Vancouver to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Vancouver to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.wa_{metroCode}.latency</td>
-		<td>Metro latency from Warsaw to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Warsaw to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.wi_{metroCode}.latency</td>
-		<td>Metro latency from Winnipeg to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Winnipeg to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.zh_{metroCode}.latency</td>
-		<td>Metro latency from Zurich to ${metroCode} is ${operator} ${operand} milliseconds</td>
+		<td>Metro latency from Zurich to ${metro} is ${operator} ${operand} milliseconds</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
@@ -1357,385 +1357,385 @@ The following data payloads are the supported events and formats for Equinix Net
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.am_{metroCode}.latency</td>
-		<td>Amsterdam to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Amsterdam to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.at_{metroCode}.latency</td>
-		<td>Atlanta to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Atlanta to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ba_{metroCode}.latency</td>
-		<td>Barcelona to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Barcelona to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.bg_{metroCode}.latency</td>
-		<td>Bogota to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Bogota to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.bl_{metroCode}.latency</td>
-		<td>Brussels to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Brussels to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.bo_{metroCode}.latency</td>
-		<td>Boston to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Boston to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.bx_{metroCode}.latency</td>
-		<td>Bordeaux to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Bordeaux to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ca_{metroCode}.latency</td>
-		<td>Canberra to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Canberra to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ch_{metroCode}.latency</td>
-		<td>Chicago to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Chicago to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.cl_{metroCode}.latency</td>
-		<td>Calgary to  ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Calgary to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.cu_{metroCode}.latency</td>
-		<td>Culpeper to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Culpeper to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.da_{metroCode}.latency</td>
-		<td>Dallas to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Dallas to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.db_{metroCode}.latency</td>
-		<td>Dublin to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Dublin to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.dc_{metroCode}.latency</td>
-		<td>Ashburn to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Ashburn to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.de_{metroCode}.latency</td>
-		<td>Denver to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Denver to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.dx_{metroCode}.latency</td>
-		<td>Dubai to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Dubai to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.fr_{metroCode}.latency</td>
-		<td>Frankfurt to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Frankfurt to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.gv_{metroCode}.latency</td>
-		<td>Geneva to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Geneva to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.he_{metroCode}.latency</td>
-		<td>Helsinki to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Helsinki to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.hh_{metroCode}.latency</td>
-		<td>Hamburg to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Hamburg to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.hk_{metroCode}.latency</td>
-		<td>Hong Kong to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Hong Kong to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ho_{metroCode}.latency</td>
-		<td>Houston to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Houston to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.il_{metroCode}.latency</td>
-		<td>Istanbul to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Istanbul to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.jh_{metroCode}.latency</td>
-		<td>Johor to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Johor to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.jk_{metroCode}.latency</td>
-		<td>Jakarta to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Jakarta to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.jn_{metroCode}.latency</td>
-		<td>Johannesburg to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Johannesburg to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ka_{metroCode}.latency</td>
-		<td>Kamloops to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Kamloops to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.kl_{metroCode}.latency</td>
-		<td>Kuala Lumpur to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Kuala Lumpur to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.la_{metroCode}.latency</td>
-		<td>Los Angeles to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Los Angeles to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ld_{metroCode}.latency</td>
-		<td>London to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>London to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.lm_{metroCode}.latency</td>
-		<td>Lima to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Lima to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ls_{metroCode}.latency</td>
-		<td>Lisbon to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Lisbon to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ma_{metroCode}.latency</td>
-		<td>Manchester to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Manchester to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mb_{metroCode}.latency</td>
-		<td>Mumbai to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Mumbai to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.md_{metroCode}.latency</td>
-		<td>Madrid to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Madrid to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.me_{metroCode}.latency</td>
-		<td>Melbourne to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Melbourne to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mi_{metroCode}.latency</td>
-		<td>Miami to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Miami to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ml_{metroCode}.latency</td>
-		<td>Milan to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Milan to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mo_{metroCode}.latency</td>
-		<td>Monterrey to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Monterrey to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mt_{metroCode}.latency</td>
-		<td>Montreal to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Montreal to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mu_{metroCode}.latency</td>
-		<td>Munich to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Munich to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mx_{metroCode}.latency</td>
-		<td>Mexico City to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Mexico City to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ny_{metroCode}.latency</td>
-		<td>New York to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>New York to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.os_{metroCode}.latency</td>
-		<td>Osaka to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Osaka to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ot_{metroCode}.latency</td>
-		<td>Ottawa to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Ottawa to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.pa_{metroCode}.latency</td>
-		<td>Paris to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Paris to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.pe_{metroCode}.latency</td>
-		<td>Perth to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Perth to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ph_{metroCode}.latency</td>
-		<td>Philadelphia to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Philadelphia to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.rj_{metroCode}.latency</td>
-		<td>Rio de Janeiro to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Rio de Janeiro to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.se_{metroCode}.latency</td>
-		<td>Seattle to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Seattle to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sg_{metroCode}.latency</td>
-		<td>Singapore to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Singapore to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sk_{metroCode}.latency</td>
-		<td>Stockholm to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Stockholm to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sl_{metroCode}.latency</td>
-		<td>Seoul to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Seoul to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.so_{metroCode}.latency</td>
-		<td>Sofia to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Sofia to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sp_{metroCode}.latency</td>
-		<td>Sao Paulo to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Sao Paulo to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.st_{metroCode}.latency</td>
-		<td>Santiago to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Santiago to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sv_{metroCode}.latency</td>
-		<td>Silicon Valley to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Silicon Valley to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sy_{metroCode}.latency</td>
-		<td>Sydney to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Sydney to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.tr_{metroCode}.latency</td>
-		<td>Toronto to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Toronto to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ty_{metroCode}.latency</td>
-		<td>Tokyo to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Tokyo to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.va_{metroCode}.latency</td>
-		<td>Vancouver to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Vancouver to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.wa_{metroCode}.latency</td>
-		<td>Warsaw to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Warsaw to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.wi_{metroCode}.latency</td>
-		<td>Winnipeg to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Winnipeg to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.zh_{metroCode}.latency</td>
-		<td>Zurich to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Zurich to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
@@ -1797,385 +1797,385 @@ The following data payloads are the supported events and formats for Equinix Net
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.am_{metroCode}.latency</td>
-		<td>Metro latency from Amsterdam to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Amsterdam to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.at_{metroCode}.latency</td>
-		<td>Metro latency from Atlanta to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Atlanta to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ba_{metroCode}.latency</td>
-		<td>Metro latency from Barcelona to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Barcelona to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.bg_{metroCode}.latency</td>
-		<td>Metro latency from Bogota to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Bogota to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.bl_{metroCode}.latency</td>
-		<td>Metro latency from Brussels to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Brussels to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.bo_{metroCode}.latency</td>
-		<td>Metro latency from Boston to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Boston to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.bx_{metroCode}.latency</td>
-		<td>Metro latency from Bordeaux to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Bordeaux to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ca_{metroCode}.latency</td>
-		<td>Metro latency from Canberra to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Canberra to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ch_{metroCode}.latency</td>
-		<td>Metro latency from Chicago to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Chicago to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.cl_{metroCode}.latency</td>
-		<td>Metro latency from Calgary to  ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Calgary to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.cu_{metroCode}.latency</td>
-		<td>Metro latency from Culpeper to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Culpeper to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.da_{metroCode}.latency</td>
-		<td>Metro latency from Dallas to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Dallas to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.db_{metroCode}.latency</td>
-		<td>Metro latency from Dublin to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Dublin to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.dc_{metroCode}.latency</td>
-		<td>Metro latency from Ashburn to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Ashburn to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.de_{metroCode}.latency</td>
-		<td>Metro latency from Denver to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Denver to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.dx_{metroCode}.latency</td>
-		<td>Metro latency from Dubai to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Dubai to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.fr_{metroCode}.latency</td>
-		<td>Metro latency from Frankfurt to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Frankfurt to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.gv_{metroCode}.latency</td>
-		<td>Metro latency from Geneva to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Geneva to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.he_{metroCode}.latency</td>
-		<td>Metro latency from Helsinki to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Helsinki to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.hh_{metroCode}.latency</td>
-		<td>Metro latency from Hamburg to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Hamburg to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.hk_{metroCode}.latency</td>
-		<td>Metro latency from Hong Kong to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Hong Kong to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ho_{metroCode}.latency</td>
-		<td>Metro latency from Houston to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Houston to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.il_{metroCode}.latency</td>
-		<td>Metro latency from Istanbul to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Istanbul to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.jh_{metroCode}.latency</td>
-		<td>Metro latency from Johor to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Johor to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.jk_{metroCode}.latency</td>
-		<td>Metro latency from Jakarta to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Jakarta to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.jn_{metroCode}.latency</td>
-		<td>Metro latency from Johannesburg to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Johannesburg to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ka_{metroCode}.latency</td>
-		<td>Metro latency from Kamloops to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Kamloops to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.kl_{metroCode}.latency</td>
-		<td>Metro latency from Kuala Lumpur to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Kuala Lumpur to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.la_{metroCode}.latency</td>
-		<td>Metro latency from Los Angeles to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Los Angeles to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ld_{metroCode}.latency</td>
-		<td>Metro latency from London to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from London to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.lm_{metroCode}.latency</td>
-		<td>Metro latency from Lima to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Lima to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ls_{metroCode}.latency</td>
-		<td>Metro latency from Lisbon to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Lisbon to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ma_{metroCode}.latency</td>
-		<td>Metro latency from Manchester to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Manchester to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mb_{metroCode}.latency</td>
-		<td>Metro latency from Mumbai to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Mumbai to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.md_{metroCode}.latency</td>
-		<td>Metro latency from Madrid to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Madrid to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.me_{metroCode}.latency</td>
-		<td>Metro latency from Melbourne to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Melbourne to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mi_{metroCode}.latency</td>
-		<td>Metro latency from Miami to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Miami to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ml_{metroCode}.latency</td>
-		<td>Metro latency from Milan to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Milan to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mo_{metroCode}.latency</td>
-		<td>Metro latency from Monterrey to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Monterrey to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mt_{metroCode}.latency</td>
-		<td>Metro latency from Montreal to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Montreal to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mu_{metroCode}.latency</td>
-		<td>Metro latency from Munich to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Munich to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mx_{metroCode}.latency</td>
-		<td>Metro latency from Mexico City to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Mexico City to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ny_{metroCode}.latency</td>
-		<td>Metro latency from New York to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from New York to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.os_{metroCode}.latency</td>
-		<td>Metro latency from Osaka to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Osaka to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ot_{metroCode}.latency</td>
-		<td>Metro latency from Ottawa to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Ottawa to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.pa_{metroCode}.latency</td>
-		<td>Metro latency from Paris to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Paris to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.pe_{metroCode}.latency</td>
-		<td>Metro latency from Perth to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Perth to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ph_{metroCode}.latency</td>
-		<td>Metro latency from Philadelphia to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Philadelphia to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.rj_{metroCode}.latency</td>
-		<td>Metro latency from Rio de Janeiro to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Rio de Janeiro to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.se_{metroCode}.latency</td>
-		<td>Metro latency from Seattle to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Seattle to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sg_{metroCode}.latency</td>
-		<td>Metro latency from Singapore to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Singapore to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sk_{metroCode}.latency</td>
-		<td>Metro latency from Stockholm to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Stockholm to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sl_{metroCode}.latency</td>
-		<td>Metro latency from Seoul to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Seoul to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.so_{metroCode}.latency</td>
-		<td>Metro latency from Sofia to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Sofia to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sp_{metroCode}.latency</td>
-		<td>Metro latency from Sao Paulo to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Sao Paulo to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.st_{metroCode}.latency</td>
-		<td>Metro latency from Santiago to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Santiago to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sv_{metroCode}.latency</td>
-		<td>Metro latency from Silicon Valley to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Silicon Valley to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sy_{metroCode}.latency</td>
-		<td>Metro latency from Sydney to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Sydney to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.tr_{metroCode}.latency</td>
-		<td>Metro latency from Toronto to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Toronto to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ty_{metroCode}.latency</td>
-		<td>Metro latency from Tokyo to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Tokyo to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.va_{metroCode}.latency</td>
-		<td>Metro latency from Vancouver to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Vancouver to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.wa_{metroCode}.latency</td>
-		<td>Metro latency from Warsaw to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Warsaw to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.wi_{metroCode}.latency</td>
-		<td>Metro latency from Winnipeg to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Winnipeg to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.zh_{metroCode}.latency</td>
-		<td>Metro latency from Zurich to ${metroCode} above ${threshold}</td>
+		<td>Metro latency from Zurich to ${metro} above ${threshold}</td>
 		<td>released</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
@@ -2215,385 +2215,385 @@ The following data payloads are the supported events and formats for Equinix Net
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.am_{metroCode}.latency</td>
-		<td>Amsterdam to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Amsterdam to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.at_{metroCode}.latency</td>
-		<td>Atlanta to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Atlanta to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ba_{metroCode}.latency</td>
-		<td>Barcelona to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Barcelona to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.bg_{metroCode}.latency</td>
-		<td>Bogota to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Bogota to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.bl_{metroCode}.latency</td>
-		<td>Brussels to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Brussels to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.bo_{metroCode}.latency</td>
-		<td>Boston to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Boston to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.bx_{metroCode}.latency</td>
-		<td>Bordeaux to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Bordeaux to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ca_{metroCode}.latency</td>
-		<td>Canberra to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Canberra to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ch_{metroCode}.latency</td>
-		<td>Chicago to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Chicago to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.cl_{metroCode}.latency</td>
-		<td>Calgary to  ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Calgary to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.cu_{metroCode}.latency</td>
-		<td>Culpeper to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Culpeper to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.da_{metroCode}.latency</td>
-		<td>Dallas to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Dallas to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.db_{metroCode}.latency</td>
-		<td>Dublin to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Dublin to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.dc_{metroCode}.latency</td>
-		<td>Ashburn to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Ashburn to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.de_{metroCode}.latency</td>
-		<td>Denver to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Denver to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.dx_{metroCode}.latency</td>
-		<td>Dubai to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Dubai to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.fr_{metroCode}.latency</td>
-		<td>Frankfurt to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Frankfurt to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.gv_{metroCode}.latency</td>
-		<td>Geneva to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Geneva to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.he_{metroCode}.latency</td>
-		<td>Helsinki to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Helsinki to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.hh_{metroCode}.latency</td>
-		<td>Hamburg to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Hamburg to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.hk_{metroCode}.latency</td>
-		<td>Hong Kong to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Hong Kong to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ho_{metroCode}.latency</td>
-		<td>Houston to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Houston to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.il_{metroCode}.latency</td>
-		<td>Istanbul to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Istanbul to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.jh_{metroCode}.latency</td>
-		<td>Johor to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Johor to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.jk_{metroCode}.latency</td>
-		<td>Jakarta to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Jakarta to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.jn_{metroCode}.latency</td>
-		<td>Johannesburg to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Johannesburg to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ka_{metroCode}.latency</td>
-		<td>Kamloops to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Kamloops to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.kl_{metroCode}.latency</td>
-		<td>Kuala Lumpur to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Kuala Lumpur to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.la_{metroCode}.latency</td>
-		<td>Los Angeles to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Los Angeles to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ld_{metroCode}.latency</td>
-		<td>London to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>London to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.lm_{metroCode}.latency</td>
-		<td>Lima to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Lima to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ls_{metroCode}.latency</td>
-		<td>Lisbon to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Lisbon to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ma_{metroCode}.latency</td>
-		<td>Manchester to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Manchester to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mb_{metroCode}.latency</td>
-		<td>Mumbai to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Mumbai to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.md_{metroCode}.latency</td>
-		<td>Madrid to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Madrid to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.me_{metroCode}.latency</td>
-		<td>Melbourne to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Melbourne to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mi_{metroCode}.latency</td>
-		<td>Miami to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Miami to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ml_{metroCode}.latency</td>
-		<td>Milan to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Milan to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mo_{metroCode}.latency</td>
-		<td>Monterrey to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Monterrey to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mt_{metroCode}.latency</td>
-		<td>Montreal to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Montreal to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mu_{metroCode}.latency</td>
-		<td>Munich to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Munich to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.mx_{metroCode}.latency</td>
-		<td>Mexico City to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Mexico City to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ny_{metroCode}.latency</td>
-		<td>New York to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>New York to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.os_{metroCode}.latency</td>
-		<td>Osaka to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Osaka to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ot_{metroCode}.latency</td>
-		<td>Ottawa to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Ottawa to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.pa_{metroCode}.latency</td>
-		<td>Paris to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Paris to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.pe_{metroCode}.latency</td>
-		<td>Perth to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Perth to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ph_{metroCode}.latency</td>
-		<td>Philadelphia to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Philadelphia to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.rj_{metroCode}.latency</td>
-		<td>Rio de Janeiro to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Rio de Janeiro to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.se_{metroCode}.latency</td>
-		<td>Seattle to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Seattle to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sg_{metroCode}.latency</td>
-		<td>Singapore to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Singapore to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sk_{metroCode}.latency</td>
-		<td>Stockholm to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Stockholm to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sl_{metroCode}.latency</td>
-		<td>Seoul to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Seoul to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.so_{metroCode}.latency</td>
-		<td>Sofia to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Sofia to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sp_{metroCode}.latency</td>
-		<td>Sao Paulo to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Sao Paulo to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.st_{metroCode}.latency</td>
-		<td>Santiago to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Santiago to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sv_{metroCode}.latency</td>
-		<td>Silicon Valley to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Silicon Valley to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.sy_{metroCode}.latency</td>
-		<td>Sydney to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Sydney to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.tr_{metroCode}.latency</td>
-		<td>Toronto to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Toronto to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.ty_{metroCode}.latency</td>
-		<td>Tokyo to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Tokyo to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.va_{metroCode}.latency</td>
-		<td>Vancouver to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Vancouver to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.wa_{metroCode}.latency</td>
-		<td>Warsaw to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Warsaw to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.wi_{metroCode}.latency</td>
-		<td>Winnipeg to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Winnipeg to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.metro.zh_{metroCode}.latency</td>
-		<td>Zurich to ${metroCode} intermetro latency, average in milliseconds</td>
+		<td>Zurich to ${metro} intermetro latency, average in milliseconds</td>
 		<td>released</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>

--- a/README.md
+++ b/README.md
@@ -2162,7 +2162,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	</tr>
 	<tr>
 		<td>equinix.fabric.metric</td>
-		<td></td>
+		<td>Metrics collected</td>
 		<td>released</td>
 	<td>-</td>
 	</tr>

--- a/jsonschema/catalog.json
+++ b/jsonschema/catalog.json
@@ -739,13 +739,13 @@
                     "name": "equinix.fabric.connection.bandwidth_rx.usage",
                     "description": "Connection inbound bandwidth usage above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.connection.bandwidth_tx.usage",
                     "description": "Connection outbound bandwidth usage above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.connection.installed_routes_ipv4.utilization",
@@ -785,373 +785,373 @@
                 },
                 {
                     "name": "equinix.fabric.metro.am_{metroCode}.latency",
-                    "description": "Metro latency from AM to ${metroCode} in ms",
+                    "description": "Metro latency from Amsterdam to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.at_{metroCode}.latency",
-                    "description": "Metro latency from AT to ${metroCode} in ms",
+                    "description": "Metro latency from Atlanta to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ba_{metroCode}.latency",
-                    "description": "Metro latency from BA to ${metroCode} in ms",
+                    "description": "Metro latency from Barcelona to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.bg_{metroCode}.latency",
-                    "description": "Metro latency from BG to ${metroCode} in ms",
+                    "description": "Metro latency from Bogota to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.bl_{metroCode}.latency",
-                    "description": "Metro latency from BL to ${metroCode} in ms",
+                    "description": "Metro latency from Brussels to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.bo_{metroCode}.latency",
-                    "description": "Metro latency from BO to ${metroCode} in ms",
+                    "description": "Metro latency from Boston to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.bx_{metroCode}.latency",
-                    "description": "Metro latency from BX to ${metroCode} in ms",
+                    "description": "Metro latency from Bordeaux to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ca_{metroCode}.latency",
-                    "description": "Metro latency from CA to ${metroCode} in ms",
+                    "description": "Metro latency from Canberra to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ch_{metroCode}.latency",
-                    "description": "Metro latency from CH to ${metroCode} in ms",
+                    "description": "Metro latency from Chicago to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.cl_{metroCode}.latency",
-                    "description": "Metro latency from CL to ${metroCode} in ms",
+                    "description": "Metro latency from Calgary to  ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.cu_{metroCode}.latency",
-                    "description": "Metro latency from CU to ${metroCode} in ms",
+                    "description": "Metro latency from Culpeper to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.da_{metroCode}.latency",
-                    "description": "Metro latency from DA to ${metroCode} in ms",
+                    "description": "Metro latency from Dallas to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.db_{metroCode}.latency",
-                    "description": "Metro latency from DB to ${metroCode} in ms",
+                    "description": "Metro latency from Dublin to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.dc_{metroCode}.latency",
-                    "description": "Metro latency from DC to ${metroCode} in ms",
+                    "description": "Metro latency from Ashburn to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.de_{metroCode}.latency",
-                    "description": "Metro latency from DE to ${metroCode} in ms",
+                    "description": "Metro latency from Denver to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.dx_{metroCode}.latency",
-                    "description": "Metro latency from DX to ${metroCode} in ms",
+                    "description": "Metro latency from Dubai to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.fr_{metroCode}.latency",
-                    "description": "Metro latency from FR to ${metroCode} in ms",
+                    "description": "Metro latency from Frankfurt to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.gv_{metroCode}.latency",
-                    "description": "Metro latency from GV to ${metroCode} in ms",
+                    "description": "Metro latency from Geneva to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.he_{metroCode}.latency",
-                    "description": "Metro latency from HE to ${metroCode} in ms",
+                    "description": "Metro latency from Helsinki to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.hh_{metroCode}.latency",
-                    "description": "Metro latency from HH to ${metroCode} in ms",
+                    "description": "Metro latency from Hamburg to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.hk_{metroCode}.latency",
-                    "description": "Metro latency from HK to ${metroCode} in ms",
+                    "description": "Metro latency from Hong Kong to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ho_{metroCode}.latency",
-                    "description": "Metro latency from HO to ${metroCode} in ms",
+                    "description": "Metro latency from Houston to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.il_{metroCode}.latency",
-                    "description": "Metro latency from IL to ${metroCode} in ms",
+                    "description": "Metro latency from Istanbul to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.jh_{metroCode}.latency",
-                    "description": "Metro latency from JH to ${metroCode} in ms",
+                    "description": "Metro latency from Johor to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ka_{metroCode}.latency",
-                    "description": "Metro latency from KA to ${metroCode} in ms",
+                    "description": "Metro latency from Kamloops to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.kl_{metroCode}.latency",
-                    "description": "Metro latency from KL to ${metroCode} in ms",
+                    "description": "Metro latency from Kuala Lumpur to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.la_{metroCode}.latency",
-                    "description": "Metro latency from LA to ${metroCode} in ms",
+                    "description": "Metro latency from Los Angeles to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ld_{metroCode}.latency",
-                    "description": "Metro latency from LD to ${metroCode} in ms",
+                    "description": "Metro latency from London to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.lm_{metroCode}.latency",
-                    "description": "Metro latency from LM to ${metroCode} in ms",
+                    "description": "Metro latency from Lima to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ls_{metroCode}.latency",
-                    "description": "Metro latency from LS to ${metroCode} in ms",
+                    "description": "Metro latency from Lisbon to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ma_{metroCode}.latency",
-                    "description": "Metro latency from MA to ${metroCode} in ms",
+                    "description": "Metro latency from Manchester to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mb_{metroCode}.latency",
-                    "description": "Metro latency from MB to ${metroCode} in ms",
+                    "description": "Metro latency from Mumbai to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.md_{metroCode}.latency",
-                    "description": "Metro latency from MD to ${metroCode} in ms",
+                    "description": "Metro latency from Madrid to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.me_{metroCode}.latency",
-                    "description": "Metro latency from ME to ${metroCode} in ms",
+                    "description": "Metro latency from Melbourne to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mi_{metroCode}.latency",
-                    "description": "Metro latency from MI to ${metroCode} in ms",
+                    "description": "Metro latency from Miami to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ml_{metroCode}.latency",
-                    "description": "Metro latency from ML to ${metroCode} in ms",
+                    "description": "Metro latency from Milan to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mo_{metroCode}.latency",
-                    "description": "Metro latency from MO to ${metroCode} in ms",
+                    "description": "Metro latency from Monterrey to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mt_{metroCode}.latency",
-                    "description": "Metro latency from MT to ${metroCode} in ms",
+                    "description": "Metro latency from Montreal to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mu_{metroCode}.latency",
-                    "description": "Metro latency from MU to ${metroCode} in ms",
+                    "description": "Metro latency from Munich to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mx_{metroCode}.latency",
-                    "description": "Metro latency from MX to ${metroCode} in ms",
+                    "description": "Metro latency from Mexico City to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ny_{metroCode}.latency",
-                    "description": "Metro latency from NY to ${metroCode} in ms",
+                    "description": "Metro latency from New York to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.os_{metroCode}.latency",
-                    "description": "Metro latency from OS to ${metroCode} in ms",
+                    "description": "Metro latency from Osaka to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ot_{metroCode}.latency",
-                    "description": "Metro latency from OT to ${metroCode} in ms",
+                    "description": "Metro latency from Ottawa to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.pa_{metroCode}.latency",
-                    "description": "Metro latency from PA to ${metroCode} in ms",
+                    "description": "Metro latency from Paris to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.pe_{metroCode}.latency",
-                    "description": "Metro latency from PE to ${metroCode} in ms",
+                    "description": "Metro latency from Perth to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ph_{metroCode}.latency",
-                    "description": "Metro latency from PH to ${metroCode} in ms",
+                    "description": "Metro latency from Philadelphia to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.rj_{metroCode}.latency",
-                    "description": "Metro latency from RJ to ${metroCode} in ms",
+                    "description": "Metro latency from Rio de Janeiro to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.se_{metroCode}.latency",
-                    "description": "Metro latency from SE to ${metroCode} in ms",
+                    "description": "Metro latency from Seattle to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sg_{metroCode}.latency",
-                    "description": "Metro latency from SG to ${metroCode} in ms",
+                    "description": "Metro latency from Singapore to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sk_{metroCode}.latency",
-                    "description": "Metro latency from SK to ${metroCode} in ms",
+                    "description": "Metro latency from Stockholm to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sl_{metroCode}.latency",
-                    "description": "Metro latency from SL to ${metroCode} in ms",
+                    "description": "Metro latency from Seoul to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.so_{metroCode}.latency",
-                    "description": "Metro latency from SO to ${metroCode} in ms",
+                    "description": "Metro latency from Sofia to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sp_{metroCode}.latency",
-                    "description": "Metro latency from SP to ${metroCode} in ms",
+                    "description": "Metro latency from Sao Paulo to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.st_{metroCode}.latency",
-                    "description": "Metro latency from ST to ${metroCode} in ms",
+                    "description": "Metro latency from Santiago to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sv_{metroCode}.latency",
-                    "description": "Metro latency from SV to ${metroCode} in ms",
+                    "description": "Metro latency from Silicon Valley to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sy_{metroCode}.latency",
-                    "description": "Metro latency from SY to ${metroCode} in ms",
+                    "description": "Metro latency from Sydney to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.tr_{metroCode}.latency",
-                    "description": "Metro latency from TR to ${metroCode} in ms",
+                    "description": "Metro latency from Toronto to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ty_{metroCode}.latency",
-                    "description": "Metro latency from TY to ${metroCode} in ms",
+                    "description": "Metro latency from Tokyo to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.va_{metroCode}.latency",
-                    "description": "Metro latency from VA to ${metroCode} in ms",
+                    "description": "Metro latency from Vancouver to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.wa_{metroCode}.latency",
-                    "description": "Metro latency from WA to ${metroCode} in ms",
+                    "description": "Metro latency from Warsaw to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.wi_{metroCode}.latency",
-                    "description": "Metro latency from WI to ${metroCode} in ms",
+                    "description": "Metro latency from Winnipeg to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.zh_{metroCode}.latency",
-                    "description": "Metro latency from ZH to ${metroCode} in ms",
+                    "description": "Metro latency from Zurich to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
@@ -1159,37 +1159,37 @@
                     "name": "equinix.fabric.port.bandwidth_rx.usage",
                     "description": "Port inbound bandwidth usage above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.port.bandwidth_tx.usage",
                     "description": "Port outbound bandwidth usage above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.port.packets_dropped_rx.count",
                     "description": "Port inbound dropped packets count above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.port.packets_dropped_tx.count",
                     "description": "Port outbound dropped packets count above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.port.packets_erred_rx.count",
                     "description": "Port inbound erred packets count above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.port.packets_erred_tx.count",
                     "description": "Port outbound erred packets count above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.router.installed_routes_ipv4.utilization",
@@ -1259,373 +1259,373 @@
                 },
                 {
                     "name": "equinix.fabric.metro.am_{metroCode}.latency",
-                    "description": "Metro latency from AM to ${metroCode} in ms",
+                    "description": "Amsterdam to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.at_{metroCode}.latency",
-                    "description": "Metro latency from AT to ${metroCode} in ms",
+                    "description": "Atlanta to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ba_{metroCode}.latency",
-                    "description": "Metro latency from BA to ${metroCode} in ms",
+                    "description": "Barcelona to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.bg_{metroCode}.latency",
-                    "description": "Metro latency from BG to ${metroCode} in ms",
+                    "description": "Bogota to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.bl_{metroCode}.latency",
-                    "description": "Metro latency from BL to ${metroCode} in ms",
+                    "description": "Brussels to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.bo_{metroCode}.latency",
-                    "description": "Metro latency from BO to ${metroCode} in ms",
+                    "description": "Boston to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.bx_{metroCode}.latency",
-                    "description": "Metro latency from BX to ${metroCode} in ms",
+                    "description": "Bordeaux to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ca_{metroCode}.latency",
-                    "description": "Metro latency from CA to ${metroCode} in ms",
+                    "description": "Canberra to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ch_{metroCode}.latency",
-                    "description": "Metro latency from CH to ${metroCode} in ms",
+                    "description": "Chicago to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.cl_{metroCode}.latency",
-                    "description": "Metro latency from CL to ${metroCode} in ms",
+                    "description": "Calgary to  ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.cu_{metroCode}.latency",
-                    "description": "Metro latency from CU to ${metroCode} in ms",
+                    "description": "Culpeper to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.da_{metroCode}.latency",
-                    "description": "Metro latency from DA to ${metroCode} in ms",
+                    "description": "Dallas to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.db_{metroCode}.latency",
-                    "description": "Metro latency from DB to ${metroCode} in ms",
+                    "description": "Dublin to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.dc_{metroCode}.latency",
-                    "description": "Metro latency from DC to ${metroCode} in ms",
+                    "description": "Ashburn to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.de_{metroCode}.latency",
-                    "description": "Metro latency from DE to ${metroCode} in ms",
+                    "description": "Denver to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.dx_{metroCode}.latency",
-                    "description": "Metro latency from DX to ${metroCode} in ms",
+                    "description": "Dubai to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.fr_{metroCode}.latency",
-                    "description": "Metro latency from FR to ${metroCode} in ms",
+                    "description": "Frankfurt to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.gv_{metroCode}.latency",
-                    "description": "Metro latency from GV to ${metroCode} in ms",
+                    "description": "Geneva to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.he_{metroCode}.latency",
-                    "description": "Metro latency from HE to ${metroCode} in ms",
+                    "description": "Helsinki to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.hh_{metroCode}.latency",
-                    "description": "Metro latency from HH to ${metroCode} in ms",
+                    "description": "Hamburg to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.hk_{metroCode}.latency",
-                    "description": "Metro latency from HK to ${metroCode} in ms",
+                    "description": "Hong Kong to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ho_{metroCode}.latency",
-                    "description": "Metro latency from HO to ${metroCode} in ms",
+                    "description": "Houston to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.il_{metroCode}.latency",
-                    "description": "Metro latency from IL to ${metroCode} in ms",
+                    "description": "Istanbul to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.jh_{metroCode}.latency",
-                    "description": "Metro latency from JH to ${metroCode} in ms",
+                    "description": "Johor to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ka_{metroCode}.latency",
-                    "description": "Metro latency from KA to ${metroCode} in ms",
+                    "description": "Kamloops to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.kl_{metroCode}.latency",
-                    "description": "Metro latency from KL to ${metroCode} in ms",
+                    "description": "Kuala Lumpur to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.la_{metroCode}.latency",
-                    "description": "Metro latency from LA to ${metroCode} in ms",
+                    "description": "Los Angeles to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ld_{metroCode}.latency",
-                    "description": "Metro latency from LD to ${metroCode} in ms",
+                    "description": "London to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.lm_{metroCode}.latency",
-                    "description": "Metro latency from LM to ${metroCode} in ms",
+                    "description": "Lima to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ls_{metroCode}.latency",
-                    "description": "Metro latency from LS to ${metroCode} in ms",
+                    "description": "Lisbon to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ma_{metroCode}.latency",
-                    "description": "Metro latency from MA to ${metroCode} in ms",
+                    "description": "Manchester to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mb_{metroCode}.latency",
-                    "description": "Metro latency from MB to ${metroCode} in ms",
+                    "description": "Mumbai to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.md_{metroCode}.latency",
-                    "description": "Metro latency from MD to ${metroCode} in ms",
+                    "description": "Madrid to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.me_{metroCode}.latency",
-                    "description": "Metro latency from ME to ${metroCode} in ms",
+                    "description": "Melbourne to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mi_{metroCode}.latency",
-                    "description": "Metro latency from MI to ${metroCode} in ms",
+                    "description": "Miami to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ml_{metroCode}.latency",
-                    "description": "Metro latency from ML to ${metroCode} in ms",
+                    "description": "Milan to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mo_{metroCode}.latency",
-                    "description": "Metro latency from MO to ${metroCode} in ms",
+                    "description": "Monterrey to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mt_{metroCode}.latency",
-                    "description": "Metro latency from MT to ${metroCode} in ms",
+                    "description": "Montreal to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mu_{metroCode}.latency",
-                    "description": "Metro latency from MU to ${metroCode} in ms",
+                    "description": "Munich to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mx_{metroCode}.latency",
-                    "description": "Metro latency from MX to ${metroCode} in ms",
+                    "description": "Mexico City to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ny_{metroCode}.latency",
-                    "description": "Metro latency from NY to ${metroCode} in ms",
+                    "description": "New York to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.os_{metroCode}.latency",
-                    "description": "Metro latency from OS to ${metroCode} in ms",
+                    "description": "Osaka to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ot_{metroCode}.latency",
-                    "description": "Metro latency from OT to ${metroCode} in ms",
+                    "description": "Ottawa to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.pa_{metroCode}.latency",
-                    "description": "Metro latency from PA to ${metroCode} in ms",
+                    "description": "Paris to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.pe_{metroCode}.latency",
-                    "description": "Metro latency from PE to ${metroCode} in ms",
+                    "description": "Perth to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ph_{metroCode}.latency",
-                    "description": "Metro latency from PH to ${metroCode} in ms",
+                    "description": "Philadelphia to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.rj_{metroCode}.latency",
-                    "description": "Metro latency from RJ to ${metroCode} in ms",
+                    "description": "Rio de Janeiro to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.se_{metroCode}.latency",
-                    "description": "Metro latency from SE to ${metroCode} in ms",
+                    "description": "Seattle to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sg_{metroCode}.latency",
-                    "description": "Metro latency from SG to ${metroCode} in ms",
+                    "description": "Singapore to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sk_{metroCode}.latency",
-                    "description": "Metro latency from SK to ${metroCode} in ms",
+                    "description": "Stockholm to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sl_{metroCode}.latency",
-                    "description": "Metro latency from SL to ${metroCode} in ms",
+                    "description": "Seoul to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.so_{metroCode}.latency",
-                    "description": "Metro latency from SO to ${metroCode} in ms",
+                    "description": "Sofia to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sp_{metroCode}.latency",
-                    "description": "Metro latency from SP to ${metroCode} in ms",
+                    "description": "Sao Paulo to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.st_{metroCode}.latency",
-                    "description": "Metro latency from ST to ${metroCode} in ms",
+                    "description": "Santiago to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sv_{metroCode}.latency",
-                    "description": "Metro latency from SV to ${metroCode} in ms",
+                    "description": "Silicon Valley to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sy_{metroCode}.latency",
-                    "description": "Metro latency from SY to ${metroCode} in ms",
+                    "description": "Sydney to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.tr_{metroCode}.latency",
-                    "description": "Metro latency from TR to ${metroCode} in ms",
+                    "description": "Toronto to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ty_{metroCode}.latency",
-                    "description": "Metro latency from TY to ${metroCode} in ms",
+                    "description": "Tokyo to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.va_{metroCode}.latency",
-                    "description": "Metro latency from VA to ${metroCode} in ms",
+                    "description": "Vancouver to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.wa_{metroCode}.latency",
-                    "description": "Metro latency from WA to ${metroCode} in ms",
+                    "description": "Warsaw to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.wi_{metroCode}.latency",
-                    "description": "Metro latency from WI to ${metroCode} in ms",
+                    "description": "Winnipeg to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.zh_{metroCode}.latency",
-                    "description": "Metro latency from ZH to ${metroCode} in ms",
+                    "description": "Zurich to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
@@ -1674,382 +1674,382 @@
             "name": "MetroLatencyAlert",
             "description": "The data within all MetricAlert events.",
             "datatype": "equinix.fabric.v1.MetroLatencyAlert",
-            "cloudeventTypes": [
+            "cloudeventTypes": [],
+            "metricNames": [],
+            "alertNames": [
                 {
                     "name": "equinix.fabric.metro.am_{metroCode}.latency",
-                    "description": "Metro latency from AM to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Amsterdam to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.at_{metroCode}.latency",
-                    "description": "Metro latency from AT to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Atlanta to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.ba_{metroCode}.latency",
-                    "description": "Metro latency from BA to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Barcelona to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.bg_{metroCode}.latency",
-                    "description": "Metro latency from BG to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Bogota to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.bl_{metroCode}.latency",
-                    "description": "Metro latency from BL to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Brussels to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.bo_{metroCode}.latency",
-                    "description": "Metro latency from BO to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Boston to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.bx_{metroCode}.latency",
-                    "description": "Metro latency from BX to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Bordeaux to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.ca_{metroCode}.latency",
-                    "description": "Metro latency from CA to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Canberra to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.ch_{metroCode}.latency",
-                    "description": "Metro latency from CH to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Chicago to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.cl_{metroCode}.latency",
-                    "description": "Metro latency from CL to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Calgary to  ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.cu_{metroCode}.latency",
-                    "description": "Metro latency from CU to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Culpeper to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.da_{metroCode}.latency",
-                    "description": "Metro latency from DA to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Dallas to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.db_{metroCode}.latency",
-                    "description": "Metro latency from DB to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Dublin to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.dc_{metroCode}.latency",
-                    "description": "Metro latency from DC to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Ashburn to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.de_{metroCode}.latency",
-                    "description": "Metro latency from DE to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Denver to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.dx_{metroCode}.latency",
-                    "description": "Metro latency from DX to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Dubai to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.fr_{metroCode}.latency",
-                    "description": "Metro latency from FR to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Frankfurt to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.gv_{metroCode}.latency",
-                    "description": "Metro latency from GV to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Geneva to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.he_{metroCode}.latency",
-                    "description": "Metro latency from HE to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Helsinki to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.hh_{metroCode}.latency",
-                    "description": "Metro latency from HH to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Hamburg to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.hk_{metroCode}.latency",
-                    "description": "Metro latency from HK to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Hong Kong to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.ho_{metroCode}.latency",
-                    "description": "Metro latency from HO to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Houston to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.il_{metroCode}.latency",
-                    "description": "Metro latency from IL to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Istanbul to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.jh_{metroCode}.latency",
-                    "description": "Metro latency from JH to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Johor to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.ka_{metroCode}.latency",
-                    "description": "Metro latency from KA to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Kamloops to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.kl_{metroCode}.latency",
-                    "description": "Metro latency from KL to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Kuala Lumpur to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.la_{metroCode}.latency",
-                    "description": "Metro latency from LA to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Los Angeles to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.ld_{metroCode}.latency",
-                    "description": "Metro latency from LD to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from London to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.lm_{metroCode}.latency",
-                    "description": "Metro latency from LM to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Lima to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.ls_{metroCode}.latency",
-                    "description": "Metro latency from LS to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Lisbon to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.ma_{metroCode}.latency",
-                    "description": "Metro latency from MA to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Manchester to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.mb_{metroCode}.latency",
-                    "description": "Metro latency from MB to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Mumbai to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.md_{metroCode}.latency",
-                    "description": "Metro latency from MD to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Madrid to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.me_{metroCode}.latency",
-                    "description": "Metro latency from ME to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Melbourne to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.mi_{metroCode}.latency",
-                    "description": "Metro latency from MI to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Miami to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.ml_{metroCode}.latency",
-                    "description": "Metro latency from ML to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Milan to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.mo_{metroCode}.latency",
-                    "description": "Metro latency from MO to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Monterrey to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.mt_{metroCode}.latency",
-                    "description": "Metro latency from MT to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Montreal to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.mu_{metroCode}.latency",
-                    "description": "Metro latency from MU to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Munich to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.mx_{metroCode}.latency",
-                    "description": "Metro latency from MX to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Mexico City to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.ny_{metroCode}.latency",
-                    "description": "Metro latency from NY to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from New York to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.os_{metroCode}.latency",
-                    "description": "Metro latency from OS to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Osaka to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.ot_{metroCode}.latency",
-                    "description": "Metro latency from OT to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Ottawa to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.pa_{metroCode}.latency",
-                    "description": "Metro latency from PA to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Paris to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.pe_{metroCode}.latency",
-                    "description": "Metro latency from PE to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Perth to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.ph_{metroCode}.latency",
-                    "description": "Metro latency from PH to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Philadelphia to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.rj_{metroCode}.latency",
-                    "description": "Metro latency from RJ to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Rio de Janeiro to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.se_{metroCode}.latency",
-                    "description": "Metro latency from SE to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Seattle to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.sg_{metroCode}.latency",
-                    "description": "Metro latency from SG to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Singapore to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.sk_{metroCode}.latency",
-                    "description": "Metro latency from SK to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Stockholm to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.sl_{metroCode}.latency",
-                    "description": "Metro latency from SL to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Seoul to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.so_{metroCode}.latency",
-                    "description": "Metro latency from SO to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Sofia to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.sp_{metroCode}.latency",
-                    "description": "Metro latency from SP to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Sao Paulo to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.st_{metroCode}.latency",
-                    "description": "Metro latency from ST to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Santiago to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.sv_{metroCode}.latency",
-                    "description": "Metro latency from SV to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Silicon Valley to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.sy_{metroCode}.latency",
-                    "description": "Metro latency from SY to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Sydney to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.tr_{metroCode}.latency",
-                    "description": "Metro latency from TR to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Toronto to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.ty_{metroCode}.latency",
-                    "description": "Metro latency from TY to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Tokyo to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.va_{metroCode}.latency",
-                    "description": "Metro latency from VA to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Vancouver to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.wa_{metroCode}.latency",
-                    "description": "Metro latency from WA to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Warsaw to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.wi_{metroCode}.latency",
-                    "description": "Metro latency from WI to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Winnipeg to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.zh_{metroCode}.latency",
-                    "description": "Metro latency from ZH to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Zurich to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "preview"
                 }
-            ],
-            "metricNames": [],
-            "alertNames": []
+            ]
         },
         {
             "url": "https://equinix.github.io/equinix-cloudevents/jsonschema/equinix/fabric/v1/MetroLatencyMetric.json",
@@ -2068,373 +2068,373 @@
             "metricNames": [
                 {
                     "name": "equinix.fabric.metro.am_{metroCode}.latency",
-                    "description": "Metro latency from AM to ${metroCode} in ms",
+                    "description": "Amsterdam to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.at_{metroCode}.latency",
-                    "description": "Metro latency from AT to ${metroCode} in ms",
+                    "description": "Atlanta to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ba_{metroCode}.latency",
-                    "description": "Metro latency from BA to ${metroCode} in ms",
+                    "description": "Barcelona to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.bg_{metroCode}.latency",
-                    "description": "Metro latency from BG to ${metroCode} in ms",
+                    "description": "Bogota to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.bl_{metroCode}.latency",
-                    "description": "Metro latency from BL to ${metroCode} in ms",
+                    "description": "Brussels to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.bo_{metroCode}.latency",
-                    "description": "Metro latency from BO to ${metroCode} in ms",
+                    "description": "Boston to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.bx_{metroCode}.latency",
-                    "description": "Metro latency from BX to ${metroCode} in ms",
+                    "description": "Bordeaux to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ca_{metroCode}.latency",
-                    "description": "Metro latency from CA to ${metroCode} in ms",
+                    "description": "Canberra to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ch_{metroCode}.latency",
-                    "description": "Metro latency from CH to ${metroCode} in ms",
+                    "description": "Chicago to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.cl_{metroCode}.latency",
-                    "description": "Metro latency from CL to ${metroCode} in ms",
+                    "description": "Calgary to  ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.cu_{metroCode}.latency",
-                    "description": "Metro latency from CU to ${metroCode} in ms",
+                    "description": "Culpeper to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.da_{metroCode}.latency",
-                    "description": "Metro latency from DA to ${metroCode} in ms",
+                    "description": "Dallas to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.db_{metroCode}.latency",
-                    "description": "Metro latency from DB to ${metroCode} in ms",
+                    "description": "Dublin to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.dc_{metroCode}.latency",
-                    "description": "Metro latency from DC to ${metroCode} in ms",
+                    "description": "Ashburn to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.de_{metroCode}.latency",
-                    "description": "Metro latency from DE to ${metroCode} in ms",
+                    "description": "Denver to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.dx_{metroCode}.latency",
-                    "description": "Metro latency from DX to ${metroCode} in ms",
+                    "description": "Dubai to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.fr_{metroCode}.latency",
-                    "description": "Metro latency from FR to ${metroCode} in ms",
+                    "description": "Frankfurt to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.gv_{metroCode}.latency",
-                    "description": "Metro latency from GV to ${metroCode} in ms",
+                    "description": "Geneva to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.he_{metroCode}.latency",
-                    "description": "Metro latency from HE to ${metroCode} in ms",
+                    "description": "Helsinki to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.hh_{metroCode}.latency",
-                    "description": "Metro latency from HH to ${metroCode} in ms",
+                    "description": "Hamburg to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.hk_{metroCode}.latency",
-                    "description": "Metro latency from HK to ${metroCode} in ms",
+                    "description": "Hong Kong to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ho_{metroCode}.latency",
-                    "description": "Metro latency from HO to ${metroCode} in ms",
+                    "description": "Houston to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.il_{metroCode}.latency",
-                    "description": "Metro latency from IL to ${metroCode} in ms",
+                    "description": "Istanbul to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.jh_{metroCode}.latency",
-                    "description": "Metro latency from JH to ${metroCode} in ms",
+                    "description": "Johor to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ka_{metroCode}.latency",
-                    "description": "Metro latency from KA to ${metroCode} in ms",
+                    "description": "Kamloops to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.kl_{metroCode}.latency",
-                    "description": "Metro latency from KL to ${metroCode} in ms",
+                    "description": "Kuala Lumpur to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.la_{metroCode}.latency",
-                    "description": "Metro latency from LA to ${metroCode} in ms",
+                    "description": "Los Angeles to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ld_{metroCode}.latency",
-                    "description": "Metro latency from LD to ${metroCode} in ms",
+                    "description": "London to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.lm_{metroCode}.latency",
-                    "description": "Metro latency from LM to ${metroCode} in ms",
+                    "description": "Lima to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ls_{metroCode}.latency",
-                    "description": "Metro latency from LS to ${metroCode} in ms",
+                    "description": "Lisbon to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ma_{metroCode}.latency",
-                    "description": "Metro latency from MA to ${metroCode} in ms",
+                    "description": "Manchester to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mb_{metroCode}.latency",
-                    "description": "Metro latency from MB to ${metroCode} in ms",
+                    "description": "Mumbai to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.md_{metroCode}.latency",
-                    "description": "Metro latency from MD to ${metroCode} in ms",
+                    "description": "Madrid to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.me_{metroCode}.latency",
-                    "description": "Metro latency from ME to ${metroCode} in ms",
+                    "description": "Melbourne to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mi_{metroCode}.latency",
-                    "description": "Metro latency from MI to ${metroCode} in ms",
+                    "description": "Miami to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ml_{metroCode}.latency",
-                    "description": "Metro latency from ML to ${metroCode} in ms",
+                    "description": "Milan to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mo_{metroCode}.latency",
-                    "description": "Metro latency from MO to ${metroCode} in ms",
+                    "description": "Monterrey to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mt_{metroCode}.latency",
-                    "description": "Metro latency from MT to ${metroCode} in ms",
+                    "description": "Montreal to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mu_{metroCode}.latency",
-                    "description": "Metro latency from MU to ${metroCode} in ms",
+                    "description": "Munich to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mx_{metroCode}.latency",
-                    "description": "Metro latency from MX to ${metroCode} in ms",
+                    "description": "Mexico City to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ny_{metroCode}.latency",
-                    "description": "Metro latency from NY to ${metroCode} in ms",
+                    "description": "New York to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.os_{metroCode}.latency",
-                    "description": "Metro latency from OS to ${metroCode} in ms",
+                    "description": "Osaka to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ot_{metroCode}.latency",
-                    "description": "Metro latency from OT to ${metroCode} in ms",
+                    "description": "Ottawa to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.pa_{metroCode}.latency",
-                    "description": "Metro latency from PA to ${metroCode} in ms",
+                    "description": "Paris to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.pe_{metroCode}.latency",
-                    "description": "Metro latency from PE to ${metroCode} in ms",
+                    "description": "Perth to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ph_{metroCode}.latency",
-                    "description": "Metro latency from PH to ${metroCode} in ms",
+                    "description": "Philadelphia to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.rj_{metroCode}.latency",
-                    "description": "Metro latency from RJ to ${metroCode} in ms",
+                    "description": "Rio de Janeiro to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.se_{metroCode}.latency",
-                    "description": "Metro latency from SE to ${metroCode} in ms",
+                    "description": "Seattle to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sg_{metroCode}.latency",
-                    "description": "Metro latency from SG to ${metroCode} in ms",
+                    "description": "Singapore to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sk_{metroCode}.latency",
-                    "description": "Metro latency from SK to ${metroCode} in ms",
+                    "description": "Stockholm to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sl_{metroCode}.latency",
-                    "description": "Metro latency from SL to ${metroCode} in ms",
+                    "description": "Seoul to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.so_{metroCode}.latency",
-                    "description": "Metro latency from SO to ${metroCode} in ms",
+                    "description": "Sofia to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sp_{metroCode}.latency",
-                    "description": "Metro latency from SP to ${metroCode} in ms",
+                    "description": "Sao Paulo to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.st_{metroCode}.latency",
-                    "description": "Metro latency from ST to ${metroCode} in ms",
+                    "description": "Santiago to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sv_{metroCode}.latency",
-                    "description": "Metro latency from SV to ${metroCode} in ms",
+                    "description": "Silicon Valley to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sy_{metroCode}.latency",
-                    "description": "Metro latency from SY to ${metroCode} in ms",
+                    "description": "Sydney to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.tr_{metroCode}.latency",
-                    "description": "Metro latency from TR to ${metroCode} in ms",
+                    "description": "Toronto to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ty_{metroCode}.latency",
-                    "description": "Metro latency from TY to ${metroCode} in ms",
+                    "description": "Tokyo to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.va_{metroCode}.latency",
-                    "description": "Metro latency from VA to ${metroCode} in ms",
+                    "description": "Vancouver to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.wa_{metroCode}.latency",
-                    "description": "Metro latency from WA to ${metroCode} in ms",
+                    "description": "Warsaw to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.wi_{metroCode}.latency",
-                    "description": "Metro latency from WI to ${metroCode} in ms",
+                    "description": "Winnipeg to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.zh_{metroCode}.latency",
-                    "description": "Metro latency from ZH to ${metroCode} in ms",
+                    "description": "Zurich to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 }

--- a/jsonschema/catalog.json
+++ b/jsonschema/catalog.json
@@ -928,6 +928,18 @@
                     "releaseStatus": "released"
                 },
                 {
+                    "name": "equinix.fabric.metro.jk_{metroCode}.latency",
+                    "description": "Metro latency from Jakarta to ${metroCode} above ${threshold}",
+                    "sloCategoryCode": "BLUE_ALERT_SLO",
+                    "releaseStatus": "released"
+                },
+                {
+                    "name": "equinix.fabric.metro.jn_{metroCode}.latency",
+                    "description": "Metro latency from Johannesburg to ${metroCode} above ${threshold}",
+                    "sloCategoryCode": "BLUE_ALERT_SLO",
+                    "releaseStatus": "released"
+                },
+                {
                     "name": "equinix.fabric.metro.ka_{metroCode}.latency",
                     "description": "Metro latency from Kamloops to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
@@ -1402,6 +1414,18 @@
                     "releaseStatus": "released"
                 },
                 {
+                    "name": "equinix.fabric.metro.jk_{metroCode}.latency",
+                    "description": "Jakarta to ${metroCode} intermetro latency, average in milliseconds",
+                    "sloCategoryCode": "BROWN_METRIC_SLO",
+                    "releaseStatus": "released"
+                },
+                {
+                    "name": "equinix.fabric.metro.jn_{metroCode}.latency",
+                    "description": "Johannesburg to ${metroCode} intermetro latency, average in milliseconds",
+                    "sloCategoryCode": "BROWN_METRIC_SLO",
+                    "releaseStatus": "released"
+                },
+                {
                     "name": "equinix.fabric.metro.ka_{metroCode}.latency",
                     "description": "Kamloops to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
@@ -1822,6 +1846,18 @@
                     "releaseStatus": "released"
                 },
                 {
+                    "name": "equinix.fabric.metro.jk_{metroCode}.latency",
+                    "description": "Metro latency from Jakarta to ${metroCode} above ${threshold}",
+                    "sloCategoryCode": "BLUE_ALERT_SLO",
+                    "releaseStatus": "released"
+                },
+                {
+                    "name": "equinix.fabric.metro.jn_{metroCode}.latency",
+                    "description": "Metro latency from Johannesburg to ${metroCode} above ${threshold}",
+                    "sloCategoryCode": "BLUE_ALERT_SLO",
+                    "releaseStatus": "released"
+                },
+                {
                     "name": "equinix.fabric.metro.ka_{metroCode}.latency",
                     "description": "Metro latency from Kamloops to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
@@ -2207,6 +2243,18 @@
                 {
                     "name": "equinix.fabric.metro.jh_{metroCode}.latency",
                     "description": "Johor to ${metroCode} intermetro latency, average in milliseconds",
+                    "sloCategoryCode": "BROWN_METRIC_SLO",
+                    "releaseStatus": "released"
+                },
+                {
+                    "name": "equinix.fabric.metro.jk_{metroCode}.latency",
+                    "description": "Jakarta to ${metroCode} intermetro latency, average in milliseconds",
+                    "sloCategoryCode": "BROWN_METRIC_SLO",
+                    "releaseStatus": "released"
+                },
+                {
+                    "name": "equinix.fabric.metro.jn_{metroCode}.latency",
+                    "description": "Johannesburg to ${metroCode} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },

--- a/jsonschema/catalog.json
+++ b/jsonschema/catalog.json
@@ -1228,8 +1228,7 @@
                     "name": "equinix.fabric.metric",
                     "description": "Metrics collected",
                     "sloCategoryCode": "",
-                    "inPreview": false,
-                    "isReleased": true
+                    "releaseStatus": "released"
                 }
             ],
             "metricNames": [

--- a/jsonschema/catalog.json
+++ b/jsonschema/catalog.json
@@ -1214,7 +1214,7 @@
             "cloudeventTypes": [
                 {
                     "name": "equinix.fabric.metric",
-                    "description": "",
+                    "description": "Metrics collected",
                     "sloCategoryCode": "",
                     "inPreview": false,
                     "isReleased": true

--- a/jsonschema/catalog.json
+++ b/jsonschema/catalog.json
@@ -1681,373 +1681,373 @@
                     "name": "equinix.fabric.metro.am_{metroCode}.latency",
                     "description": "Metro latency from Amsterdam to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.at_{metroCode}.latency",
                     "description": "Metro latency from Atlanta to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ba_{metroCode}.latency",
                     "description": "Metro latency from Barcelona to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.bg_{metroCode}.latency",
                     "description": "Metro latency from Bogota to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.bl_{metroCode}.latency",
                     "description": "Metro latency from Brussels to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.bo_{metroCode}.latency",
                     "description": "Metro latency from Boston to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.bx_{metroCode}.latency",
                     "description": "Metro latency from Bordeaux to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ca_{metroCode}.latency",
                     "description": "Metro latency from Canberra to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ch_{metroCode}.latency",
                     "description": "Metro latency from Chicago to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.cl_{metroCode}.latency",
                     "description": "Metro latency from Calgary to  ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.cu_{metroCode}.latency",
                     "description": "Metro latency from Culpeper to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.da_{metroCode}.latency",
                     "description": "Metro latency from Dallas to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.db_{metroCode}.latency",
                     "description": "Metro latency from Dublin to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.dc_{metroCode}.latency",
                     "description": "Metro latency from Ashburn to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.de_{metroCode}.latency",
                     "description": "Metro latency from Denver to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.dx_{metroCode}.latency",
                     "description": "Metro latency from Dubai to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.fr_{metroCode}.latency",
                     "description": "Metro latency from Frankfurt to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.gv_{metroCode}.latency",
                     "description": "Metro latency from Geneva to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.he_{metroCode}.latency",
                     "description": "Metro latency from Helsinki to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.hh_{metroCode}.latency",
                     "description": "Metro latency from Hamburg to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.hk_{metroCode}.latency",
                     "description": "Metro latency from Hong Kong to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ho_{metroCode}.latency",
                     "description": "Metro latency from Houston to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.il_{metroCode}.latency",
                     "description": "Metro latency from Istanbul to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.jh_{metroCode}.latency",
                     "description": "Metro latency from Johor to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ka_{metroCode}.latency",
                     "description": "Metro latency from Kamloops to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.kl_{metroCode}.latency",
                     "description": "Metro latency from Kuala Lumpur to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.la_{metroCode}.latency",
                     "description": "Metro latency from Los Angeles to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ld_{metroCode}.latency",
                     "description": "Metro latency from London to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.lm_{metroCode}.latency",
                     "description": "Metro latency from Lima to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ls_{metroCode}.latency",
                     "description": "Metro latency from Lisbon to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ma_{metroCode}.latency",
                     "description": "Metro latency from Manchester to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mb_{metroCode}.latency",
                     "description": "Metro latency from Mumbai to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.md_{metroCode}.latency",
                     "description": "Metro latency from Madrid to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.me_{metroCode}.latency",
                     "description": "Metro latency from Melbourne to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mi_{metroCode}.latency",
                     "description": "Metro latency from Miami to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ml_{metroCode}.latency",
                     "description": "Metro latency from Milan to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mo_{metroCode}.latency",
                     "description": "Metro latency from Monterrey to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mt_{metroCode}.latency",
                     "description": "Metro latency from Montreal to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mu_{metroCode}.latency",
                     "description": "Metro latency from Munich to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mx_{metroCode}.latency",
                     "description": "Metro latency from Mexico City to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ny_{metroCode}.latency",
                     "description": "Metro latency from New York to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.os_{metroCode}.latency",
                     "description": "Metro latency from Osaka to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ot_{metroCode}.latency",
                     "description": "Metro latency from Ottawa to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.pa_{metroCode}.latency",
                     "description": "Metro latency from Paris to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.pe_{metroCode}.latency",
                     "description": "Metro latency from Perth to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ph_{metroCode}.latency",
                     "description": "Metro latency from Philadelphia to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.rj_{metroCode}.latency",
                     "description": "Metro latency from Rio de Janeiro to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.se_{metroCode}.latency",
                     "description": "Metro latency from Seattle to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sg_{metroCode}.latency",
                     "description": "Metro latency from Singapore to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sk_{metroCode}.latency",
                     "description": "Metro latency from Stockholm to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sl_{metroCode}.latency",
                     "description": "Metro latency from Seoul to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.so_{metroCode}.latency",
                     "description": "Metro latency from Sofia to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sp_{metroCode}.latency",
                     "description": "Metro latency from Sao Paulo to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.st_{metroCode}.latency",
                     "description": "Metro latency from Santiago to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sv_{metroCode}.latency",
                     "description": "Metro latency from Silicon Valley to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sy_{metroCode}.latency",
                     "description": "Metro latency from Sydney to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.tr_{metroCode}.latency",
                     "description": "Metro latency from Toronto to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ty_{metroCode}.latency",
                     "description": "Metro latency from Tokyo to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.va_{metroCode}.latency",
                     "description": "Metro latency from Vancouver to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.wa_{metroCode}.latency",
                     "description": "Metro latency from Warsaw to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.wi_{metroCode}.latency",
                     "description": "Metro latency from Winnipeg to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.zh_{metroCode}.latency",
                     "description": "Metro latency from Zurich to ${metroCode} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 }
             ]
         },

--- a/jsonschema/catalog.json
+++ b/jsonschema/catalog.json
@@ -2523,13 +2523,13 @@
                     "name": "equinix.identity.organization.user.added",
                     "description": "User added to org event",
                     "sloCategoryCode": "BLUE_EVENT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.identity.organization.user.removed",
                     "description": "User removed from org event",
                     "sloCategoryCode": "BLUE_EVENT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 }
             ],
             "metricNames": [],

--- a/jsonschema/catalog.json
+++ b/jsonschema/catalog.json
@@ -785,385 +785,385 @@
                 },
                 {
                     "name": "equinix.fabric.metro.am_{metroCode}.latency",
-                    "description": "Metro latency from Amsterdam to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Amsterdam to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.at_{metroCode}.latency",
-                    "description": "Metro latency from Atlanta to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Atlanta to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ba_{metroCode}.latency",
-                    "description": "Metro latency from Barcelona to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Barcelona to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.bg_{metroCode}.latency",
-                    "description": "Metro latency from Bogota to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Bogota to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.bl_{metroCode}.latency",
-                    "description": "Metro latency from Brussels to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Brussels to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.bo_{metroCode}.latency",
-                    "description": "Metro latency from Boston to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Boston to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.bx_{metroCode}.latency",
-                    "description": "Metro latency from Bordeaux to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Bordeaux to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ca_{metroCode}.latency",
-                    "description": "Metro latency from Canberra to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Canberra to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ch_{metroCode}.latency",
-                    "description": "Metro latency from Chicago to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Chicago to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.cl_{metroCode}.latency",
-                    "description": "Metro latency from Calgary to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Calgary to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.cu_{metroCode}.latency",
-                    "description": "Metro latency from Culpeper to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Culpeper to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.da_{metroCode}.latency",
-                    "description": "Metro latency from Dallas to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Dallas to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.db_{metroCode}.latency",
-                    "description": "Metro latency from Dublin to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Dublin to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.dc_{metroCode}.latency",
-                    "description": "Metro latency from Ashburn to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Ashburn to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.de_{metroCode}.latency",
-                    "description": "Metro latency from Denver to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Denver to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.dx_{metroCode}.latency",
-                    "description": "Metro latency from Dubai to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Dubai to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.fr_{metroCode}.latency",
-                    "description": "Metro latency from Frankfurt to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Frankfurt to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.gv_{metroCode}.latency",
-                    "description": "Metro latency from Geneva to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Geneva to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.he_{metroCode}.latency",
-                    "description": "Metro latency from Helsinki to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Helsinki to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.hh_{metroCode}.latency",
-                    "description": "Metro latency from Hamburg to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Hamburg to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.hk_{metroCode}.latency",
-                    "description": "Metro latency from Hong Kong to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Hong Kong to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ho_{metroCode}.latency",
-                    "description": "Metro latency from Houston to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Houston to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.il_{metroCode}.latency",
-                    "description": "Metro latency from Istanbul to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Istanbul to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.jh_{metroCode}.latency",
-                    "description": "Metro latency from Johor to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Johor to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.jk_{metroCode}.latency",
-                    "description": "Metro latency from Jakarta to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Jakarta to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.jn_{metroCode}.latency",
-                    "description": "Metro latency from Johannesburg to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Johannesburg to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ka_{metroCode}.latency",
-                    "description": "Metro latency from Kamloops to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Kamloops to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.kl_{metroCode}.latency",
-                    "description": "Metro latency from Kuala Lumpur to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Kuala Lumpur to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.la_{metroCode}.latency",
-                    "description": "Metro latency from Los Angeles to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Los Angeles to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ld_{metroCode}.latency",
-                    "description": "Metro latency from London to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from London to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.lm_{metroCode}.latency",
-                    "description": "Metro latency from Lima to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Lima to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ls_{metroCode}.latency",
-                    "description": "Metro latency from Lisbon to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Lisbon to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ma_{metroCode}.latency",
-                    "description": "Metro latency from Manchester to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Manchester to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mb_{metroCode}.latency",
-                    "description": "Metro latency from Mumbai to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Mumbai to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.md_{metroCode}.latency",
-                    "description": "Metro latency from Madrid to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Madrid to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.me_{metroCode}.latency",
-                    "description": "Metro latency from Melbourne to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Melbourne to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mi_{metroCode}.latency",
-                    "description": "Metro latency from Miami to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Miami to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ml_{metroCode}.latency",
-                    "description": "Metro latency from Milan to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Milan to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mo_{metroCode}.latency",
-                    "description": "Metro latency from Monterrey to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Monterrey to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mt_{metroCode}.latency",
-                    "description": "Metro latency from Montreal to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Montreal to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mu_{metroCode}.latency",
-                    "description": "Metro latency from Munich to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Munich to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mx_{metroCode}.latency",
-                    "description": "Metro latency from Mexico City to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Mexico City to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ny_{metroCode}.latency",
-                    "description": "Metro latency from New York to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from New York to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.os_{metroCode}.latency",
-                    "description": "Metro latency from Osaka to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Osaka to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ot_{metroCode}.latency",
-                    "description": "Metro latency from Ottawa to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Ottawa to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.pa_{metroCode}.latency",
-                    "description": "Metro latency from Paris to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Paris to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.pe_{metroCode}.latency",
-                    "description": "Metro latency from Perth to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Perth to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ph_{metroCode}.latency",
-                    "description": "Metro latency from Philadelphia to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Philadelphia to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.rj_{metroCode}.latency",
-                    "description": "Metro latency from Rio de Janeiro to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Rio de Janeiro to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.se_{metroCode}.latency",
-                    "description": "Metro latency from Seattle to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Seattle to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sg_{metroCode}.latency",
-                    "description": "Metro latency from Singapore to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Singapore to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sk_{metroCode}.latency",
-                    "description": "Metro latency from Stockholm to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Stockholm to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sl_{metroCode}.latency",
-                    "description": "Metro latency from Seoul to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Seoul to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.so_{metroCode}.latency",
-                    "description": "Metro latency from Sofia to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Sofia to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sp_{metroCode}.latency",
-                    "description": "Metro latency from Sao Paulo to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Sao Paulo to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.st_{metroCode}.latency",
-                    "description": "Metro latency from Santiago to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Santiago to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sv_{metroCode}.latency",
-                    "description": "Metro latency from Silicon Valley to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Silicon Valley to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sy_{metroCode}.latency",
-                    "description": "Metro latency from Sydney to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Sydney to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.tr_{metroCode}.latency",
-                    "description": "Metro latency from Toronto to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Toronto to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ty_{metroCode}.latency",
-                    "description": "Metro latency from Tokyo to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Tokyo to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.va_{metroCode}.latency",
-                    "description": "Metro latency from Vancouver to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Vancouver to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.wa_{metroCode}.latency",
-                    "description": "Metro latency from Warsaw to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Warsaw to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.wi_{metroCode}.latency",
-                    "description": "Metro latency from Winnipeg to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Winnipeg to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.zh_{metroCode}.latency",
-                    "description": "Metro latency from Zurich to ${metroCode} is ${operator} ${operand} milliseconds",
+                    "description": "Metro latency from Zurich to ${metro} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
@@ -1271,385 +1271,385 @@
                 },
                 {
                     "name": "equinix.fabric.metro.am_{metroCode}.latency",
-                    "description": "Amsterdam to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Amsterdam to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.at_{metroCode}.latency",
-                    "description": "Atlanta to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Atlanta to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ba_{metroCode}.latency",
-                    "description": "Barcelona to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Barcelona to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.bg_{metroCode}.latency",
-                    "description": "Bogota to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Bogota to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.bl_{metroCode}.latency",
-                    "description": "Brussels to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Brussels to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.bo_{metroCode}.latency",
-                    "description": "Boston to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Boston to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.bx_{metroCode}.latency",
-                    "description": "Bordeaux to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Bordeaux to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ca_{metroCode}.latency",
-                    "description": "Canberra to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Canberra to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ch_{metroCode}.latency",
-                    "description": "Chicago to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Chicago to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.cl_{metroCode}.latency",
-                    "description": "Calgary to  ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Calgary to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.cu_{metroCode}.latency",
-                    "description": "Culpeper to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Culpeper to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.da_{metroCode}.latency",
-                    "description": "Dallas to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Dallas to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.db_{metroCode}.latency",
-                    "description": "Dublin to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Dublin to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.dc_{metroCode}.latency",
-                    "description": "Ashburn to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Ashburn to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.de_{metroCode}.latency",
-                    "description": "Denver to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Denver to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.dx_{metroCode}.latency",
-                    "description": "Dubai to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Dubai to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.fr_{metroCode}.latency",
-                    "description": "Frankfurt to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Frankfurt to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.gv_{metroCode}.latency",
-                    "description": "Geneva to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Geneva to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.he_{metroCode}.latency",
-                    "description": "Helsinki to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Helsinki to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.hh_{metroCode}.latency",
-                    "description": "Hamburg to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Hamburg to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.hk_{metroCode}.latency",
-                    "description": "Hong Kong to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Hong Kong to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ho_{metroCode}.latency",
-                    "description": "Houston to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Houston to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.il_{metroCode}.latency",
-                    "description": "Istanbul to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Istanbul to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.jh_{metroCode}.latency",
-                    "description": "Johor to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Johor to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.jk_{metroCode}.latency",
-                    "description": "Jakarta to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Jakarta to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.jn_{metroCode}.latency",
-                    "description": "Johannesburg to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Johannesburg to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ka_{metroCode}.latency",
-                    "description": "Kamloops to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Kamloops to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.kl_{metroCode}.latency",
-                    "description": "Kuala Lumpur to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Kuala Lumpur to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.la_{metroCode}.latency",
-                    "description": "Los Angeles to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Los Angeles to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ld_{metroCode}.latency",
-                    "description": "London to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "London to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.lm_{metroCode}.latency",
-                    "description": "Lima to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Lima to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ls_{metroCode}.latency",
-                    "description": "Lisbon to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Lisbon to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ma_{metroCode}.latency",
-                    "description": "Manchester to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Manchester to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mb_{metroCode}.latency",
-                    "description": "Mumbai to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Mumbai to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.md_{metroCode}.latency",
-                    "description": "Madrid to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Madrid to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.me_{metroCode}.latency",
-                    "description": "Melbourne to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Melbourne to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mi_{metroCode}.latency",
-                    "description": "Miami to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Miami to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ml_{metroCode}.latency",
-                    "description": "Milan to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Milan to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mo_{metroCode}.latency",
-                    "description": "Monterrey to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Monterrey to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mt_{metroCode}.latency",
-                    "description": "Montreal to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Montreal to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mu_{metroCode}.latency",
-                    "description": "Munich to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Munich to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mx_{metroCode}.latency",
-                    "description": "Mexico City to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Mexico City to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ny_{metroCode}.latency",
-                    "description": "New York to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "New York to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.os_{metroCode}.latency",
-                    "description": "Osaka to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Osaka to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ot_{metroCode}.latency",
-                    "description": "Ottawa to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Ottawa to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.pa_{metroCode}.latency",
-                    "description": "Paris to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Paris to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.pe_{metroCode}.latency",
-                    "description": "Perth to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Perth to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ph_{metroCode}.latency",
-                    "description": "Philadelphia to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Philadelphia to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.rj_{metroCode}.latency",
-                    "description": "Rio de Janeiro to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Rio de Janeiro to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.se_{metroCode}.latency",
-                    "description": "Seattle to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Seattle to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sg_{metroCode}.latency",
-                    "description": "Singapore to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Singapore to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sk_{metroCode}.latency",
-                    "description": "Stockholm to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Stockholm to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sl_{metroCode}.latency",
-                    "description": "Seoul to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Seoul to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.so_{metroCode}.latency",
-                    "description": "Sofia to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Sofia to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sp_{metroCode}.latency",
-                    "description": "Sao Paulo to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Sao Paulo to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.st_{metroCode}.latency",
-                    "description": "Santiago to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Santiago to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sv_{metroCode}.latency",
-                    "description": "Silicon Valley to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Silicon Valley to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sy_{metroCode}.latency",
-                    "description": "Sydney to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Sydney to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.tr_{metroCode}.latency",
-                    "description": "Toronto to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Toronto to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ty_{metroCode}.latency",
-                    "description": "Tokyo to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Tokyo to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.va_{metroCode}.latency",
-                    "description": "Vancouver to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Vancouver to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.wa_{metroCode}.latency",
-                    "description": "Warsaw to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Warsaw to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.wi_{metroCode}.latency",
-                    "description": "Winnipeg to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Winnipeg to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.zh_{metroCode}.latency",
-                    "description": "Zurich to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Zurich to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
@@ -1703,385 +1703,385 @@
             "alertNames": [
                 {
                     "name": "equinix.fabric.metro.am_{metroCode}.latency",
-                    "description": "Metro latency from Amsterdam to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Amsterdam to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.at_{metroCode}.latency",
-                    "description": "Metro latency from Atlanta to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Atlanta to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ba_{metroCode}.latency",
-                    "description": "Metro latency from Barcelona to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Barcelona to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.bg_{metroCode}.latency",
-                    "description": "Metro latency from Bogota to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Bogota to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.bl_{metroCode}.latency",
-                    "description": "Metro latency from Brussels to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Brussels to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.bo_{metroCode}.latency",
-                    "description": "Metro latency from Boston to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Boston to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.bx_{metroCode}.latency",
-                    "description": "Metro latency from Bordeaux to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Bordeaux to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ca_{metroCode}.latency",
-                    "description": "Metro latency from Canberra to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Canberra to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ch_{metroCode}.latency",
-                    "description": "Metro latency from Chicago to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Chicago to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.cl_{metroCode}.latency",
-                    "description": "Metro latency from Calgary to  ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Calgary to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.cu_{metroCode}.latency",
-                    "description": "Metro latency from Culpeper to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Culpeper to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.da_{metroCode}.latency",
-                    "description": "Metro latency from Dallas to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Dallas to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.db_{metroCode}.latency",
-                    "description": "Metro latency from Dublin to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Dublin to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.dc_{metroCode}.latency",
-                    "description": "Metro latency from Ashburn to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Ashburn to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.de_{metroCode}.latency",
-                    "description": "Metro latency from Denver to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Denver to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.dx_{metroCode}.latency",
-                    "description": "Metro latency from Dubai to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Dubai to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.fr_{metroCode}.latency",
-                    "description": "Metro latency from Frankfurt to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Frankfurt to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.gv_{metroCode}.latency",
-                    "description": "Metro latency from Geneva to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Geneva to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.he_{metroCode}.latency",
-                    "description": "Metro latency from Helsinki to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Helsinki to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.hh_{metroCode}.latency",
-                    "description": "Metro latency from Hamburg to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Hamburg to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.hk_{metroCode}.latency",
-                    "description": "Metro latency from Hong Kong to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Hong Kong to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ho_{metroCode}.latency",
-                    "description": "Metro latency from Houston to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Houston to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.il_{metroCode}.latency",
-                    "description": "Metro latency from Istanbul to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Istanbul to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.jh_{metroCode}.latency",
-                    "description": "Metro latency from Johor to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Johor to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.jk_{metroCode}.latency",
-                    "description": "Metro latency from Jakarta to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Jakarta to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.jn_{metroCode}.latency",
-                    "description": "Metro latency from Johannesburg to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Johannesburg to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ka_{metroCode}.latency",
-                    "description": "Metro latency from Kamloops to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Kamloops to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.kl_{metroCode}.latency",
-                    "description": "Metro latency from Kuala Lumpur to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Kuala Lumpur to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.la_{metroCode}.latency",
-                    "description": "Metro latency from Los Angeles to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Los Angeles to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ld_{metroCode}.latency",
-                    "description": "Metro latency from London to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from London to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.lm_{metroCode}.latency",
-                    "description": "Metro latency from Lima to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Lima to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ls_{metroCode}.latency",
-                    "description": "Metro latency from Lisbon to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Lisbon to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ma_{metroCode}.latency",
-                    "description": "Metro latency from Manchester to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Manchester to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mb_{metroCode}.latency",
-                    "description": "Metro latency from Mumbai to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Mumbai to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.md_{metroCode}.latency",
-                    "description": "Metro latency from Madrid to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Madrid to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.me_{metroCode}.latency",
-                    "description": "Metro latency from Melbourne to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Melbourne to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mi_{metroCode}.latency",
-                    "description": "Metro latency from Miami to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Miami to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ml_{metroCode}.latency",
-                    "description": "Metro latency from Milan to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Milan to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mo_{metroCode}.latency",
-                    "description": "Metro latency from Monterrey to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Monterrey to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mt_{metroCode}.latency",
-                    "description": "Metro latency from Montreal to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Montreal to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mu_{metroCode}.latency",
-                    "description": "Metro latency from Munich to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Munich to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mx_{metroCode}.latency",
-                    "description": "Metro latency from Mexico City to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Mexico City to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ny_{metroCode}.latency",
-                    "description": "Metro latency from New York to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from New York to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.os_{metroCode}.latency",
-                    "description": "Metro latency from Osaka to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Osaka to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ot_{metroCode}.latency",
-                    "description": "Metro latency from Ottawa to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Ottawa to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.pa_{metroCode}.latency",
-                    "description": "Metro latency from Paris to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Paris to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.pe_{metroCode}.latency",
-                    "description": "Metro latency from Perth to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Perth to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ph_{metroCode}.latency",
-                    "description": "Metro latency from Philadelphia to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Philadelphia to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.rj_{metroCode}.latency",
-                    "description": "Metro latency from Rio de Janeiro to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Rio de Janeiro to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.se_{metroCode}.latency",
-                    "description": "Metro latency from Seattle to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Seattle to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sg_{metroCode}.latency",
-                    "description": "Metro latency from Singapore to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Singapore to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sk_{metroCode}.latency",
-                    "description": "Metro latency from Stockholm to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Stockholm to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sl_{metroCode}.latency",
-                    "description": "Metro latency from Seoul to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Seoul to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.so_{metroCode}.latency",
-                    "description": "Metro latency from Sofia to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Sofia to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sp_{metroCode}.latency",
-                    "description": "Metro latency from Sao Paulo to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Sao Paulo to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.st_{metroCode}.latency",
-                    "description": "Metro latency from Santiago to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Santiago to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sv_{metroCode}.latency",
-                    "description": "Metro latency from Silicon Valley to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Silicon Valley to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sy_{metroCode}.latency",
-                    "description": "Metro latency from Sydney to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Sydney to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.tr_{metroCode}.latency",
-                    "description": "Metro latency from Toronto to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Toronto to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ty_{metroCode}.latency",
-                    "description": "Metro latency from Tokyo to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Tokyo to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.va_{metroCode}.latency",
-                    "description": "Metro latency from Vancouver to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Vancouver to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.wa_{metroCode}.latency",
-                    "description": "Metro latency from Warsaw to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Warsaw to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.wi_{metroCode}.latency",
-                    "description": "Metro latency from Winnipeg to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Winnipeg to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.zh_{metroCode}.latency",
-                    "description": "Metro latency from Zurich to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Zurich to ${metro} above ${threshold}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 }
@@ -2104,385 +2104,385 @@
             "metricNames": [
                 {
                     "name": "equinix.fabric.metro.am_{metroCode}.latency",
-                    "description": "Amsterdam to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Amsterdam to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.at_{metroCode}.latency",
-                    "description": "Atlanta to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Atlanta to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ba_{metroCode}.latency",
-                    "description": "Barcelona to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Barcelona to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.bg_{metroCode}.latency",
-                    "description": "Bogota to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Bogota to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.bl_{metroCode}.latency",
-                    "description": "Brussels to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Brussels to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.bo_{metroCode}.latency",
-                    "description": "Boston to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Boston to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.bx_{metroCode}.latency",
-                    "description": "Bordeaux to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Bordeaux to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ca_{metroCode}.latency",
-                    "description": "Canberra to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Canberra to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ch_{metroCode}.latency",
-                    "description": "Chicago to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Chicago to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.cl_{metroCode}.latency",
-                    "description": "Calgary to  ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Calgary to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.cu_{metroCode}.latency",
-                    "description": "Culpeper to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Culpeper to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.da_{metroCode}.latency",
-                    "description": "Dallas to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Dallas to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.db_{metroCode}.latency",
-                    "description": "Dublin to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Dublin to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.dc_{metroCode}.latency",
-                    "description": "Ashburn to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Ashburn to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.de_{metroCode}.latency",
-                    "description": "Denver to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Denver to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.dx_{metroCode}.latency",
-                    "description": "Dubai to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Dubai to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.fr_{metroCode}.latency",
-                    "description": "Frankfurt to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Frankfurt to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.gv_{metroCode}.latency",
-                    "description": "Geneva to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Geneva to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.he_{metroCode}.latency",
-                    "description": "Helsinki to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Helsinki to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.hh_{metroCode}.latency",
-                    "description": "Hamburg to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Hamburg to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.hk_{metroCode}.latency",
-                    "description": "Hong Kong to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Hong Kong to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ho_{metroCode}.latency",
-                    "description": "Houston to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Houston to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.il_{metroCode}.latency",
-                    "description": "Istanbul to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Istanbul to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.jh_{metroCode}.latency",
-                    "description": "Johor to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Johor to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.jk_{metroCode}.latency",
-                    "description": "Jakarta to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Jakarta to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.jn_{metroCode}.latency",
-                    "description": "Johannesburg to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Johannesburg to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ka_{metroCode}.latency",
-                    "description": "Kamloops to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Kamloops to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.kl_{metroCode}.latency",
-                    "description": "Kuala Lumpur to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Kuala Lumpur to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.la_{metroCode}.latency",
-                    "description": "Los Angeles to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Los Angeles to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ld_{metroCode}.latency",
-                    "description": "London to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "London to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.lm_{metroCode}.latency",
-                    "description": "Lima to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Lima to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ls_{metroCode}.latency",
-                    "description": "Lisbon to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Lisbon to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ma_{metroCode}.latency",
-                    "description": "Manchester to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Manchester to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mb_{metroCode}.latency",
-                    "description": "Mumbai to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Mumbai to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.md_{metroCode}.latency",
-                    "description": "Madrid to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Madrid to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.me_{metroCode}.latency",
-                    "description": "Melbourne to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Melbourne to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mi_{metroCode}.latency",
-                    "description": "Miami to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Miami to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ml_{metroCode}.latency",
-                    "description": "Milan to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Milan to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mo_{metroCode}.latency",
-                    "description": "Monterrey to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Monterrey to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mt_{metroCode}.latency",
-                    "description": "Montreal to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Montreal to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mu_{metroCode}.latency",
-                    "description": "Munich to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Munich to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mx_{metroCode}.latency",
-                    "description": "Mexico City to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Mexico City to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ny_{metroCode}.latency",
-                    "description": "New York to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "New York to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.os_{metroCode}.latency",
-                    "description": "Osaka to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Osaka to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ot_{metroCode}.latency",
-                    "description": "Ottawa to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Ottawa to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.pa_{metroCode}.latency",
-                    "description": "Paris to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Paris to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.pe_{metroCode}.latency",
-                    "description": "Perth to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Perth to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ph_{metroCode}.latency",
-                    "description": "Philadelphia to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Philadelphia to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.rj_{metroCode}.latency",
-                    "description": "Rio de Janeiro to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Rio de Janeiro to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.se_{metroCode}.latency",
-                    "description": "Seattle to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Seattle to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sg_{metroCode}.latency",
-                    "description": "Singapore to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Singapore to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sk_{metroCode}.latency",
-                    "description": "Stockholm to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Stockholm to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sl_{metroCode}.latency",
-                    "description": "Seoul to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Seoul to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.so_{metroCode}.latency",
-                    "description": "Sofia to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Sofia to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sp_{metroCode}.latency",
-                    "description": "Sao Paulo to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Sao Paulo to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.st_{metroCode}.latency",
-                    "description": "Santiago to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Santiago to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sv_{metroCode}.latency",
-                    "description": "Silicon Valley to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Silicon Valley to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sy_{metroCode}.latency",
-                    "description": "Sydney to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Sydney to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.tr_{metroCode}.latency",
-                    "description": "Toronto to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Toronto to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ty_{metroCode}.latency",
-                    "description": "Tokyo to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Tokyo to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.va_{metroCode}.latency",
-                    "description": "Vancouver to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Vancouver to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.wa_{metroCode}.latency",
-                    "description": "Warsaw to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Warsaw to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.wi_{metroCode}.latency",
-                    "description": "Winnipeg to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Winnipeg to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.zh_{metroCode}.latency",
-                    "description": "Zurich to ${metroCode} intermetro latency, average in milliseconds",
+                    "description": "Zurich to ${metro} intermetro latency, average in milliseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
                     "releaseStatus": "released"
                 }

--- a/jsonschema/catalog.json
+++ b/jsonschema/catalog.json
@@ -737,193 +737,193 @@
             "alertNames": [
                 {
                     "name": "equinix.fabric.connection.bandwidth_rx.usage",
-                    "description": "Connection inbound bandwidth usage above ${threshold}",
+                    "description": "Connection inbound bandwidth usage is ${operator} ${operand} bit/s",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.connection.bandwidth_tx.usage",
-                    "description": "Connection outbound bandwidth usage above ${threshold}",
+                    "description": "Connection outbound bandwidth usage is ${operator} ${operand} bit/s",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.connection.installed_routes_ipv4.utilization",
-                    "description": "Utilization of connection '${connection_name}' active IPv4 routes reached ${threshold}",
+                    "description": "Utilization of connection active IPv4 routes is ${operator} ${operand}",
                     "sloCategoryCode": "BROWN_EVENT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.connection.installed_routes_ipv6.utilization",
-                    "description": "Utilization of connection '${connection_name}' active IPv6 routes reached ${threshold}",
+                    "description": "Utilization of connection active IPv6 routes is ${operator} ${operand}",
                     "sloCategoryCode": "BROWN_EVENT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.connection.packets_dropped_rx_aside_rateexceeded.count",
-                    "description": "Connection A side inbound dropped packets count above ${threshold}",
+                    "description": "Connection A side inbound dropped packets count is ${operator} ${operand}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.connection.packets_dropped_rx_zside_rateexceeded.count",
-                    "description": "Connection Z side inbound dropped packets count above ${threshold}",
+                    "description": "Connection Z side inbound dropped packets count is ${operator} ${operand}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.connection.packets_dropped_tx_aside_rateexceeded.count",
-                    "description": "Connection A side outbound dropped packets count above ${threshold}",
+                    "description": "Connection A side outbound dropped packets count is ${operator} ${operand}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.connection.packets_dropped_tx_zside_rateexceeded.count",
-                    "description": "Connection Z side outbound dropped packets count above ${threshold}",
+                    "description": "Connection Z side outbound dropped packets count is ${operator} ${operand}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.am_{metroCode}.latency",
-                    "description": "Metro latency from Amsterdam to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Amsterdam to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.at_{metroCode}.latency",
-                    "description": "Metro latency from Atlanta to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Atlanta to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ba_{metroCode}.latency",
-                    "description": "Metro latency from Barcelona to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Barcelona to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.bg_{metroCode}.latency",
-                    "description": "Metro latency from Bogota to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Bogota to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.bl_{metroCode}.latency",
-                    "description": "Metro latency from Brussels to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Brussels to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.bo_{metroCode}.latency",
-                    "description": "Metro latency from Boston to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Boston to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.bx_{metroCode}.latency",
-                    "description": "Metro latency from Bordeaux to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Bordeaux to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ca_{metroCode}.latency",
-                    "description": "Metro latency from Canberra to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Canberra to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ch_{metroCode}.latency",
-                    "description": "Metro latency from Chicago to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Chicago to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.cl_{metroCode}.latency",
-                    "description": "Metro latency from Calgary to  ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Calgary to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.cu_{metroCode}.latency",
-                    "description": "Metro latency from Culpeper to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Culpeper to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.da_{metroCode}.latency",
-                    "description": "Metro latency from Dallas to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Dallas to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.db_{metroCode}.latency",
-                    "description": "Metro latency from Dublin to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Dublin to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.dc_{metroCode}.latency",
-                    "description": "Metro latency from Ashburn to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Ashburn to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.de_{metroCode}.latency",
-                    "description": "Metro latency from Denver to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Denver to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.dx_{metroCode}.latency",
-                    "description": "Metro latency from Dubai to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Dubai to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.fr_{metroCode}.latency",
-                    "description": "Metro latency from Frankfurt to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Frankfurt to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.gv_{metroCode}.latency",
-                    "description": "Metro latency from Geneva to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Geneva to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.he_{metroCode}.latency",
-                    "description": "Metro latency from Helsinki to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Helsinki to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.hh_{metroCode}.latency",
-                    "description": "Metro latency from Hamburg to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Hamburg to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.hk_{metroCode}.latency",
-                    "description": "Metro latency from Hong Kong to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Hong Kong to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ho_{metroCode}.latency",
-                    "description": "Metro latency from Houston to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Houston to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.il_{metroCode}.latency",
-                    "description": "Metro latency from Istanbul to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Istanbul to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.jh_{metroCode}.latency",
-                    "description": "Metro latency from Johor to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Johor to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
@@ -941,277 +941,277 @@
                 },
                 {
                     "name": "equinix.fabric.metro.ka_{metroCode}.latency",
-                    "description": "Metro latency from Kamloops to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Kamloops to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.kl_{metroCode}.latency",
-                    "description": "Metro latency from Kuala Lumpur to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Kuala Lumpur to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.la_{metroCode}.latency",
-                    "description": "Metro latency from Los Angeles to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Los Angeles to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ld_{metroCode}.latency",
-                    "description": "Metro latency from London to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from London to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.lm_{metroCode}.latency",
-                    "description": "Metro latency from Lima to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Lima to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ls_{metroCode}.latency",
-                    "description": "Metro latency from Lisbon to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Lisbon to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ma_{metroCode}.latency",
-                    "description": "Metro latency from Manchester to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Manchester to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mb_{metroCode}.latency",
-                    "description": "Metro latency from Mumbai to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Mumbai to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.md_{metroCode}.latency",
-                    "description": "Metro latency from Madrid to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Madrid to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.me_{metroCode}.latency",
-                    "description": "Metro latency from Melbourne to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Melbourne to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mi_{metroCode}.latency",
-                    "description": "Metro latency from Miami to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Miami to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ml_{metroCode}.latency",
-                    "description": "Metro latency from Milan to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Milan to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mo_{metroCode}.latency",
-                    "description": "Metro latency from Monterrey to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Monterrey to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mt_{metroCode}.latency",
-                    "description": "Metro latency from Montreal to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Montreal to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mu_{metroCode}.latency",
-                    "description": "Metro latency from Munich to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Munich to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.mx_{metroCode}.latency",
-                    "description": "Metro latency from Mexico City to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Mexico City to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ny_{metroCode}.latency",
-                    "description": "Metro latency from New York to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from New York to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.os_{metroCode}.latency",
-                    "description": "Metro latency from Osaka to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Osaka to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ot_{metroCode}.latency",
-                    "description": "Metro latency from Ottawa to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Ottawa to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.pa_{metroCode}.latency",
-                    "description": "Metro latency from Paris to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Paris to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.pe_{metroCode}.latency",
-                    "description": "Metro latency from Perth to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Perth to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ph_{metroCode}.latency",
-                    "description": "Metro latency from Philadelphia to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Philadelphia to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.rj_{metroCode}.latency",
-                    "description": "Metro latency from Rio de Janeiro to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Rio de Janeiro to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.se_{metroCode}.latency",
-                    "description": "Metro latency from Seattle to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Seattle to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sg_{metroCode}.latency",
-                    "description": "Metro latency from Singapore to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Singapore to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sk_{metroCode}.latency",
-                    "description": "Metro latency from Stockholm to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Stockholm to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sl_{metroCode}.latency",
-                    "description": "Metro latency from Seoul to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Seoul to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.so_{metroCode}.latency",
-                    "description": "Metro latency from Sofia to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Sofia to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sp_{metroCode}.latency",
-                    "description": "Metro latency from Sao Paulo to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Sao Paulo to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.st_{metroCode}.latency",
-                    "description": "Metro latency from Santiago to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Santiago to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sv_{metroCode}.latency",
-                    "description": "Metro latency from Silicon Valley to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Silicon Valley to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.sy_{metroCode}.latency",
-                    "description": "Metro latency from Sydney to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Sydney to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.tr_{metroCode}.latency",
-                    "description": "Metro latency from Toronto to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Toronto to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.ty_{metroCode}.latency",
-                    "description": "Metro latency from Tokyo to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Tokyo to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.va_{metroCode}.latency",
-                    "description": "Metro latency from Vancouver to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Vancouver to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.wa_{metroCode}.latency",
-                    "description": "Metro latency from Warsaw to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Warsaw to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.wi_{metroCode}.latency",
-                    "description": "Metro latency from Winnipeg to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Winnipeg to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.metro.zh_{metroCode}.latency",
-                    "description": "Metro latency from Zurich to ${metroCode} above ${threshold}",
+                    "description": "Metro latency from Zurich to ${metroCode} is ${operator} ${operand} milliseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.port.bandwidth_rx.usage",
-                    "description": "Port inbound bandwidth usage above ${threshold}",
+                    "description": "Port inbound bandwidth usage is ${operator} ${operand} bit/s",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.port.bandwidth_tx.usage",
-                    "description": "Port outbound bandwidth usage above ${threshold}",
+                    "description": "Port outbound bandwidth usage is ${operator} ${operand} bit/s",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.port.packets_dropped_rx.count",
-                    "description": "Port inbound dropped packets count above ${threshold}",
+                    "description": "Port inbound dropped packets count is ${operator} ${operand}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.port.packets_dropped_tx.count",
-                    "description": "Port outbound dropped packets count above ${threshold}",
+                    "description": "Port outbound dropped packets count is ${operator} ${operand}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.port.packets_erred_rx.count",
-                    "description": "Port inbound erred packets count above ${threshold}",
+                    "description": "Port inbound erred packets count is ${operator} ${operand}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.port.packets_erred_tx.count",
-                    "description": "Port outbound erred packets count above ${threshold}",
+                    "description": "Port outbound erred packets count is ${operator} ${operand}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.router.installed_routes_ipv4.utilization",
-                    "description": "Utilization of router '${router_name}' total IPv4 routes reached ${threshold}",
+                    "description": "Utilization of router total IPv4 routes is ${operator} ${operand}",
                     "sloCategoryCode": "BROWN_EVENT_SLO",
                     "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.router.installed_routes_ipv6.utilization",
-                    "description": "Utilization of router '${router_name}' total IPv6 routes reached ${threshold}",
+                    "description": "Utilization of router total IPv6 routes is ${operator} ${operand}",
                     "sloCategoryCode": "BROWN_EVENT_SLO",
                     "releaseStatus": "released"
                 }

--- a/jsonschema/catalog.json
+++ b/jsonschema/catalog.json
@@ -2060,7 +2060,7 @@
             "cloudeventTypes": [
                 {
                     "name": "equinix.fabric.metric",
-                    "description": "",
+                    "description": "Metrics collected",
                     "sloCategoryCode": "",
                     "releaseStatus": "released"
                 }

--- a/jsonschema/equinix/fabric/v1/MetricAlert.json
+++ b/jsonschema/equinix/fabric/v1/MetricAlert.json
@@ -159,241 +159,241 @@
     "alertNames": [
         {
             "name": "equinix.fabric.connection.installed_routes_ipv4.utilization",
-            "description": "Utilization of connection '${connection_name}' active IPv4 routes reached ${threshold}",
+            "description": "Utilization of connection active IPv4 routes is ${operator} ${operand}",
             "sloCategoryCode": "BROWN_EVENT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.connection.installed_routes_ipv6.utilization",
-            "description": "Utilization of connection '${connection_name}' active IPv6 routes reached ${threshold}",
+            "description": "Utilization of connection active IPv6 routes is ${operator} ${operand}",
             "sloCategoryCode": "BROWN_EVENT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.router.installed_routes_ipv4.utilization",
-            "description": "Utilization of router '${router_name}' total IPv4 routes reached ${threshold}",
+            "description": "Utilization of router total IPv4 routes is ${operator} ${operand}",
             "sloCategoryCode": "BROWN_EVENT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.router.installed_routes_ipv6.utilization",
-            "description": "Utilization of router '${router_name}' total IPv6 routes reached ${threshold}",
+            "description": "Utilization of router total IPv6 routes is ${operator} ${operand}",
             "sloCategoryCode": "BROWN_EVENT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.connection.packets_dropped_rx_aside_rateexceeded.count",
-            "description": "Connection A side inbound dropped packets count above ${threshold}",
+            "description": "Connection A side inbound dropped packets count is ${operator} ${operand}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.connection.packets_dropped_tx_aside_rateexceeded.count",
-            "description": "Connection A side outbound dropped packets count above ${threshold}",
+            "description": "Connection A side outbound dropped packets count is ${operator} ${operand}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.connection.packets_dropped_rx_zside_rateexceeded.count",
-            "description": "Connection Z side inbound dropped packets count above ${threshold}",
+            "description": "Connection Z side inbound dropped packets count is ${operator} ${operand}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.connection.packets_dropped_tx_zside_rateexceeded.count",
-            "description": "Connection Z side outbound dropped packets count above ${threshold}",
+            "description": "Connection Z side outbound dropped packets count is ${operator} ${operand}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.connection.bandwidth_rx.usage",
-            "description": "Connection inbound bandwidth usage above ${threshold}",
+            "description": "Connection inbound bandwidth usage is ${operator} ${operand} bit/s",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.connection.bandwidth_tx.usage",
-            "description": "Connection outbound bandwidth usage above ${threshold}",
+            "description": "Connection outbound bandwidth usage is ${operator} ${operand} bit/s",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.port.bandwidth_rx.usage",
-            "description": "Port inbound bandwidth usage above ${threshold}",
+            "description": "Port inbound bandwidth usage is ${operator} ${operand} bit/s",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.port.bandwidth_tx.usage",
-            "description": "Port outbound bandwidth usage above ${threshold}",
+            "description": "Port outbound bandwidth usage is ${operator} ${operand} bit/s",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.port.packets_erred_rx.count",
-            "description": "Port inbound erred packets count above ${threshold}",
+            "description": "Port inbound erred packets count is ${operator} ${operand}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.port.packets_erred_tx.count",
-            "description": "Port outbound erred packets count above ${threshold}",
+            "description": "Port outbound erred packets count is ${operator} ${operand}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.port.packets_dropped_rx.count",
-            "description": "Port inbound dropped packets count above ${threshold}",
+            "description": "Port inbound dropped packets count is ${operator} ${operand}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.port.packets_dropped_tx.count",
-            "description": "Port outbound dropped packets count above ${threshold}",
+            "description": "Port outbound dropped packets count is ${operator} ${operand}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.am_{metroCode}.latency",
-            "description": "Metro latency from Amsterdam to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Amsterdam to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.at_{metroCode}.latency",
-            "description": "Metro latency from Atlanta to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Atlanta to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ba_{metroCode}.latency",
-            "description": "Metro latency from Barcelona to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Barcelona to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.bg_{metroCode}.latency",
-            "description": "Metro latency from Bogota to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Bogota to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.bl_{metroCode}.latency",
-            "description": "Metro latency from Brussels to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Brussels to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.bo_{metroCode}.latency",
-            "description": "Metro latency from Boston to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Boston to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.bx_{metroCode}.latency",
-            "description": "Metro latency from Bordeaux to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Bordeaux to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ca_{metroCode}.latency",
-            "description": "Metro latency from Canberra to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Canberra to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ch_{metroCode}.latency",
-            "description": "Metro latency from Chicago to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Chicago to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.cl_{metroCode}.latency",
-            "description": "Metro latency from Calgary to  ${metroCode} above ${threshold}",
+            "description": "Metro latency from Calgary to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.cu_{metroCode}.latency",
-            "description": "Metro latency from Culpeper to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Culpeper to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.da_{metroCode}.latency",
-            "description": "Metro latency from Dallas to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Dallas to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.db_{metroCode}.latency",
-            "description": "Metro latency from Dublin to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Dublin to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.dc_{metroCode}.latency",
-            "description": "Metro latency from Ashburn to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Ashburn to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.de_{metroCode}.latency",
-            "description": "Metro latency from Denver to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Denver to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.dx_{metroCode}.latency",
-            "description": "Metro latency from Dubai to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Dubai to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.fr_{metroCode}.latency",
-            "description": "Metro latency from Frankfurt to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Frankfurt to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.gv_{metroCode}.latency",
-            "description": "Metro latency from Geneva to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Geneva to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.he_{metroCode}.latency",
-            "description": "Metro latency from Helsinki to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Helsinki to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.hh_{metroCode}.latency",
-            "description": "Metro latency from Hamburg to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Hamburg to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.hk_{metroCode}.latency",
-            "description": "Metro latency from Hong Kong to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Hong Kong to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ho_{metroCode}.latency",
-            "description": "Metro latency from Houston to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Houston to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.il_{metroCode}.latency",
-            "description": "Metro latency from Istanbul to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Istanbul to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.jh_{metroCode}.latency",
-            "description": "Metro latency from Johor to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Johor to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
@@ -411,229 +411,229 @@
         },
         {
             "name": "equinix.fabric.metro.ka_{metroCode}.latency",
-            "description": "Metro latency from Kamloops to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Kamloops to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.kl_{metroCode}.latency",
-            "description": "Metro latency from Kuala Lumpur to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Kuala Lumpur to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.la_{metroCode}.latency",
-            "description": "Metro latency from Los Angeles to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Los Angeles to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ld_{metroCode}.latency",
-            "description": "Metro latency from London to ${metroCode} above ${threshold}",
+            "description": "Metro latency from London to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.lm_{metroCode}.latency",
-            "description": "Metro latency from Lima to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Lima to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ls_{metroCode}.latency",
-            "description": "Metro latency from Lisbon to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Lisbon to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ma_{metroCode}.latency",
-            "description": "Metro latency from Manchester to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Manchester to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mb_{metroCode}.latency",
-            "description": "Metro latency from Mumbai to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Mumbai to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.md_{metroCode}.latency",
-            "description": "Metro latency from Madrid to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Madrid to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.me_{metroCode}.latency",
-            "description": "Metro latency from Melbourne to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Melbourne to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mi_{metroCode}.latency",
-            "description": "Metro latency from Miami to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Miami to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ml_{metroCode}.latency",
-            "description": "Metro latency from Milan to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Milan to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mo_{metroCode}.latency",
-            "description": "Metro latency from Monterrey to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Monterrey to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mt_{metroCode}.latency",
-            "description": "Metro latency from Montreal to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Montreal to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mu_{metroCode}.latency",
-            "description": "Metro latency from Munich to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Munich to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mx_{metroCode}.latency",
-            "description": "Metro latency from Mexico City to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Mexico City to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ny_{metroCode}.latency",
-            "description": "Metro latency from New York to ${metroCode} above ${threshold}",
+            "description": "Metro latency from New York to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.os_{metroCode}.latency",
-            "description": "Metro latency from Osaka to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Osaka to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ot_{metroCode}.latency",
-            "description": "Metro latency from Ottawa to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Ottawa to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.pa_{metroCode}.latency",
-            "description": "Metro latency from Paris to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Paris to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.pe_{metroCode}.latency",
-            "description": "Metro latency from Perth to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Perth to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ph_{metroCode}.latency",
-            "description": "Metro latency from Philadelphia to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Philadelphia to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.rj_{metroCode}.latency",
-            "description": "Metro latency from Rio de Janeiro to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Rio de Janeiro to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.se_{metroCode}.latency",
-            "description": "Metro latency from Seattle to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Seattle to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sg_{metroCode}.latency",
-            "description": "Metro latency from Singapore to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Singapore to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sk_{metroCode}.latency",
-            "description": "Metro latency from Stockholm to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Stockholm to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sl_{metroCode}.latency",
-            "description": "Metro latency from Seoul to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Seoul to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.so_{metroCode}.latency",
-            "description": "Metro latency from Sofia to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Sofia to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sp_{metroCode}.latency",
-            "description": "Metro latency from Sao Paulo to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Sao Paulo to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.st_{metroCode}.latency",
-            "description": "Metro latency from Santiago to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Santiago to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sv_{metroCode}.latency",
-            "description": "Metro latency from Silicon Valley to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Silicon Valley to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sy_{metroCode}.latency",
-            "description": "Metro latency from Sydney to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Sydney to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.tr_{metroCode}.latency",
-            "description": "Metro latency from Toronto to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Toronto to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ty_{metroCode}.latency",
-            "description": "Metro latency from Tokyo to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Tokyo to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.va_{metroCode}.latency",
-            "description": "Metro latency from Vancouver to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Vancouver to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.wa_{metroCode}.latency",
-            "description": "Metro latency from Warsaw to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Warsaw to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.wi_{metroCode}.latency",
-            "description": "Metro latency from Winnipeg to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Winnipeg to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.zh_{metroCode}.latency",
-            "description": "Metro latency from Zurich to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Zurich to ${metroCode} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         }

--- a/jsonschema/equinix/fabric/v1/MetricAlert.json
+++ b/jsonschema/equinix/fabric/v1/MetricAlert.json
@@ -255,385 +255,385 @@
         },
         {
             "name": "equinix.fabric.metro.am_{metroCode}.latency",
-            "description": "Metro latency from Amsterdam to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Amsterdam to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.at_{metroCode}.latency",
-            "description": "Metro latency from Atlanta to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Atlanta to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ba_{metroCode}.latency",
-            "description": "Metro latency from Barcelona to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Barcelona to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.bg_{metroCode}.latency",
-            "description": "Metro latency from Bogota to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Bogota to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.bl_{metroCode}.latency",
-            "description": "Metro latency from Brussels to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Brussels to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.bo_{metroCode}.latency",
-            "description": "Metro latency from Boston to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Boston to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.bx_{metroCode}.latency",
-            "description": "Metro latency from Bordeaux to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Bordeaux to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ca_{metroCode}.latency",
-            "description": "Metro latency from Canberra to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Canberra to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ch_{metroCode}.latency",
-            "description": "Metro latency from Chicago to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Chicago to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.cl_{metroCode}.latency",
-            "description": "Metro latency from Calgary to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Calgary to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.cu_{metroCode}.latency",
-            "description": "Metro latency from Culpeper to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Culpeper to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.da_{metroCode}.latency",
-            "description": "Metro latency from Dallas to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Dallas to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.db_{metroCode}.latency",
-            "description": "Metro latency from Dublin to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Dublin to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.dc_{metroCode}.latency",
-            "description": "Metro latency from Ashburn to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Ashburn to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.de_{metroCode}.latency",
-            "description": "Metro latency from Denver to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Denver to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.dx_{metroCode}.latency",
-            "description": "Metro latency from Dubai to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Dubai to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.fr_{metroCode}.latency",
-            "description": "Metro latency from Frankfurt to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Frankfurt to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.gv_{metroCode}.latency",
-            "description": "Metro latency from Geneva to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Geneva to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.he_{metroCode}.latency",
-            "description": "Metro latency from Helsinki to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Helsinki to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.hh_{metroCode}.latency",
-            "description": "Metro latency from Hamburg to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Hamburg to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.hk_{metroCode}.latency",
-            "description": "Metro latency from Hong Kong to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Hong Kong to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ho_{metroCode}.latency",
-            "description": "Metro latency from Houston to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Houston to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.il_{metroCode}.latency",
-            "description": "Metro latency from Istanbul to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Istanbul to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.jh_{metroCode}.latency",
-            "description": "Metro latency from Johor to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Johor to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.jk_{metroCode}.latency",
-            "description": "Metro latency from Jakarta to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Jakarta to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.jn_{metroCode}.latency",
-            "description": "Metro latency from Johannesburg to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Johannesburg to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ka_{metroCode}.latency",
-            "description": "Metro latency from Kamloops to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Kamloops to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.kl_{metroCode}.latency",
-            "description": "Metro latency from Kuala Lumpur to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Kuala Lumpur to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.la_{metroCode}.latency",
-            "description": "Metro latency from Los Angeles to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Los Angeles to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ld_{metroCode}.latency",
-            "description": "Metro latency from London to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from London to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.lm_{metroCode}.latency",
-            "description": "Metro latency from Lima to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Lima to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ls_{metroCode}.latency",
-            "description": "Metro latency from Lisbon to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Lisbon to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ma_{metroCode}.latency",
-            "description": "Metro latency from Manchester to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Manchester to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mb_{metroCode}.latency",
-            "description": "Metro latency from Mumbai to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Mumbai to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.md_{metroCode}.latency",
-            "description": "Metro latency from Madrid to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Madrid to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.me_{metroCode}.latency",
-            "description": "Metro latency from Melbourne to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Melbourne to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mi_{metroCode}.latency",
-            "description": "Metro latency from Miami to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Miami to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ml_{metroCode}.latency",
-            "description": "Metro latency from Milan to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Milan to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mo_{metroCode}.latency",
-            "description": "Metro latency from Monterrey to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Monterrey to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mt_{metroCode}.latency",
-            "description": "Metro latency from Montreal to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Montreal to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mu_{metroCode}.latency",
-            "description": "Metro latency from Munich to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Munich to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mx_{metroCode}.latency",
-            "description": "Metro latency from Mexico City to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Mexico City to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ny_{metroCode}.latency",
-            "description": "Metro latency from New York to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from New York to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.os_{metroCode}.latency",
-            "description": "Metro latency from Osaka to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Osaka to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ot_{metroCode}.latency",
-            "description": "Metro latency from Ottawa to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Ottawa to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.pa_{metroCode}.latency",
-            "description": "Metro latency from Paris to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Paris to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.pe_{metroCode}.latency",
-            "description": "Metro latency from Perth to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Perth to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ph_{metroCode}.latency",
-            "description": "Metro latency from Philadelphia to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Philadelphia to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.rj_{metroCode}.latency",
-            "description": "Metro latency from Rio de Janeiro to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Rio de Janeiro to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.se_{metroCode}.latency",
-            "description": "Metro latency from Seattle to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Seattle to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sg_{metroCode}.latency",
-            "description": "Metro latency from Singapore to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Singapore to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sk_{metroCode}.latency",
-            "description": "Metro latency from Stockholm to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Stockholm to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sl_{metroCode}.latency",
-            "description": "Metro latency from Seoul to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Seoul to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.so_{metroCode}.latency",
-            "description": "Metro latency from Sofia to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Sofia to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sp_{metroCode}.latency",
-            "description": "Metro latency from Sao Paulo to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Sao Paulo to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.st_{metroCode}.latency",
-            "description": "Metro latency from Santiago to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Santiago to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sv_{metroCode}.latency",
-            "description": "Metro latency from Silicon Valley to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Silicon Valley to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sy_{metroCode}.latency",
-            "description": "Metro latency from Sydney to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Sydney to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.tr_{metroCode}.latency",
-            "description": "Metro latency from Toronto to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Toronto to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ty_{metroCode}.latency",
-            "description": "Metro latency from Tokyo to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Tokyo to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.va_{metroCode}.latency",
-            "description": "Metro latency from Vancouver to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Vancouver to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.wa_{metroCode}.latency",
-            "description": "Metro latency from Warsaw to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Warsaw to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.wi_{metroCode}.latency",
-            "description": "Metro latency from Winnipeg to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Winnipeg to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.zh_{metroCode}.latency",
-            "description": "Metro latency from Zurich to ${metroCode} is ${operator} ${operand} milliseconds",
+            "description": "Metro latency from Zurich to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         }

--- a/jsonschema/equinix/fabric/v1/MetricAlert.json
+++ b/jsonschema/equinix/fabric/v1/MetricAlert.json
@@ -398,6 +398,18 @@
             "releaseStatus": "released"
         },
         {
+            "name": "equinix.fabric.metro.jk_{metroCode}.latency",
+            "description": "Metro latency from Jakarta to ${metroCode} above ${threshold}",
+            "sloCategoryCode": "BLUE_ALERT_SLO",
+            "releaseStatus": "released"
+        },
+        {
+            "name": "equinix.fabric.metro.jn_{metroCode}.latency",
+            "description": "Metro latency from Johannesburg to ${metroCode} above ${threshold}",
+            "sloCategoryCode": "BLUE_ALERT_SLO",
+            "releaseStatus": "released"
+        },
+        {
             "name": "equinix.fabric.metro.ka_{metroCode}.latency",
             "description": "Metro latency from Kamloops to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",

--- a/jsonschema/equinix/fabric/v1/MetricAlert.json
+++ b/jsonschema/equinix/fabric/v1/MetricAlert.json
@@ -209,419 +209,419 @@
             "name": "equinix.fabric.connection.bandwidth_rx.usage",
             "description": "Connection inbound bandwidth usage above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.connection.bandwidth_tx.usage",
             "description": "Connection outbound bandwidth usage above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.port.bandwidth_rx.usage",
             "description": "Port inbound bandwidth usage above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.port.bandwidth_tx.usage",
             "description": "Port outbound bandwidth usage above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.port.packets_erred_rx.count",
             "description": "Port inbound erred packets count above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.port.packets_erred_tx.count",
             "description": "Port outbound erred packets count above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.port.packets_dropped_rx.count",
             "description": "Port inbound dropped packets count above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.port.packets_dropped_tx.count",
             "description": "Port outbound dropped packets count above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.am_{metroCode}.latency",
-            "description": "Metro latency from AM to ${metroCode} in ms",
+            "description": "Metro latency from Amsterdam to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.at_{metroCode}.latency",
-            "description": "Metro latency from AT to ${metroCode} in ms",
+            "description": "Metro latency from Atlanta to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ba_{metroCode}.latency",
-            "description": "Metro latency from BA to ${metroCode} in ms",
+            "description": "Metro latency from Barcelona to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.bg_{metroCode}.latency",
-            "description": "Metro latency from BG to ${metroCode} in ms",
+            "description": "Metro latency from Bogota to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.bl_{metroCode}.latency",
-            "description": "Metro latency from BL to ${metroCode} in ms",
+            "description": "Metro latency from Brussels to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.bo_{metroCode}.latency",
-            "description": "Metro latency from BO to ${metroCode} in ms",
+            "description": "Metro latency from Boston to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.bx_{metroCode}.latency",
-            "description": "Metro latency from BX to ${metroCode} in ms",
+            "description": "Metro latency from Bordeaux to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ca_{metroCode}.latency",
-            "description": "Metro latency from CA to ${metroCode} in ms",
+            "description": "Metro latency from Canberra to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ch_{metroCode}.latency",
-            "description": "Metro latency from CH to ${metroCode} in ms",
+            "description": "Metro latency from Chicago to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.cl_{metroCode}.latency",
-            "description": "Metro latency from CL to ${metroCode} in ms",
+            "description": "Metro latency from Calgary to  ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.cu_{metroCode}.latency",
-            "description": "Metro latency from CU to ${metroCode} in ms",
+            "description": "Metro latency from Culpeper to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.da_{metroCode}.latency",
-            "description": "Metro latency from DA to ${metroCode} in ms",
+            "description": "Metro latency from Dallas to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.db_{metroCode}.latency",
-            "description": "Metro latency from DB to ${metroCode} in ms",
+            "description": "Metro latency from Dublin to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.dc_{metroCode}.latency",
-            "description": "Metro latency from DC to ${metroCode} in ms",
+            "description": "Metro latency from Ashburn to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.de_{metroCode}.latency",
-            "description": "Metro latency from DE to ${metroCode} in ms",
+            "description": "Metro latency from Denver to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.dx_{metroCode}.latency",
-            "description": "Metro latency from DX to ${metroCode} in ms",
+            "description": "Metro latency from Dubai to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.fr_{metroCode}.latency",
-            "description": "Metro latency from FR to ${metroCode} in ms",
+            "description": "Metro latency from Frankfurt to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.gv_{metroCode}.latency",
-            "description": "Metro latency from GV to ${metroCode} in ms",
+            "description": "Metro latency from Geneva to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.he_{metroCode}.latency",
-            "description": "Metro latency from HE to ${metroCode} in ms",
+            "description": "Metro latency from Helsinki to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.hh_{metroCode}.latency",
-            "description": "Metro latency from HH to ${metroCode} in ms",
+            "description": "Metro latency from Hamburg to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.hk_{metroCode}.latency",
-            "description": "Metro latency from HK to ${metroCode} in ms",
+            "description": "Metro latency from Hong Kong to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ho_{metroCode}.latency",
-            "description": "Metro latency from HO to ${metroCode} in ms",
+            "description": "Metro latency from Houston to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.il_{metroCode}.latency",
-            "description": "Metro latency from IL to ${metroCode} in ms",
+            "description": "Metro latency from Istanbul to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.jh_{metroCode}.latency",
-            "description": "Metro latency from JH to ${metroCode} in ms",
+            "description": "Metro latency from Johor to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ka_{metroCode}.latency",
-            "description": "Metro latency from KA to ${metroCode} in ms",
+            "description": "Metro latency from Kamloops to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.kl_{metroCode}.latency",
-            "description": "Metro latency from KL to ${metroCode} in ms",
+            "description": "Metro latency from Kuala Lumpur to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.la_{metroCode}.latency",
-            "description": "Metro latency from LA to ${metroCode} in ms",
+            "description": "Metro latency from Los Angeles to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ld_{metroCode}.latency",
-            "description": "Metro latency from LD to ${metroCode} in ms",
+            "description": "Metro latency from London to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.lm_{metroCode}.latency",
-            "description": "Metro latency from LM to ${metroCode} in ms",
+            "description": "Metro latency from Lima to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ls_{metroCode}.latency",
-            "description": "Metro latency from LS to ${metroCode} in ms",
+            "description": "Metro latency from Lisbon to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ma_{metroCode}.latency",
-            "description": "Metro latency from MA to ${metroCode} in ms",
+            "description": "Metro latency from Manchester to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mb_{metroCode}.latency",
-            "description": "Metro latency from MB to ${metroCode} in ms",
+            "description": "Metro latency from Mumbai to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.md_{metroCode}.latency",
-            "description": "Metro latency from MD to ${metroCode} in ms",
+            "description": "Metro latency from Madrid to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.me_{metroCode}.latency",
-            "description": "Metro latency from ME to ${metroCode} in ms",
+            "description": "Metro latency from Melbourne to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mi_{metroCode}.latency",
-            "description": "Metro latency from MI to ${metroCode} in ms",
+            "description": "Metro latency from Miami to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ml_{metroCode}.latency",
-            "description": "Metro latency from ML to ${metroCode} in ms",
+            "description": "Metro latency from Milan to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mo_{metroCode}.latency",
-            "description": "Metro latency from MO to ${metroCode} in ms",
+            "description": "Metro latency from Monterrey to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mt_{metroCode}.latency",
-            "description": "Metro latency from MT to ${metroCode} in ms",
+            "description": "Metro latency from Montreal to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mu_{metroCode}.latency",
-            "description": "Metro latency from MU to ${metroCode} in ms",
+            "description": "Metro latency from Munich to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mx_{metroCode}.latency",
-            "description": "Metro latency from MX to ${metroCode} in ms",
+            "description": "Metro latency from Mexico City to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ny_{metroCode}.latency",
-            "description": "Metro latency from NY to ${metroCode} in ms",
+            "description": "Metro latency from New York to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.os_{metroCode}.latency",
-            "description": "Metro latency from OS to ${metroCode} in ms",
+            "description": "Metro latency from Osaka to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ot_{metroCode}.latency",
-            "description": "Metro latency from OT to ${metroCode} in ms",
+            "description": "Metro latency from Ottawa to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.pa_{metroCode}.latency",
-            "description": "Metro latency from PA to ${metroCode} in ms",
+            "description": "Metro latency from Paris to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.pe_{metroCode}.latency",
-            "description": "Metro latency from PE to ${metroCode} in ms",
+            "description": "Metro latency from Perth to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ph_{metroCode}.latency",
-            "description": "Metro latency from PH to ${metroCode} in ms",
+            "description": "Metro latency from Philadelphia to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.rj_{metroCode}.latency",
-            "description": "Metro latency from RJ to ${metroCode} in ms",
+            "description": "Metro latency from Rio de Janeiro to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.se_{metroCode}.latency",
-            "description": "Metro latency from SE to ${metroCode} in ms",
+            "description": "Metro latency from Seattle to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sg_{metroCode}.latency",
-            "description": "Metro latency from SG to ${metroCode} in ms",
+            "description": "Metro latency from Singapore to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sk_{metroCode}.latency",
-            "description": "Metro latency from SK to ${metroCode} in ms",
+            "description": "Metro latency from Stockholm to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sl_{metroCode}.latency",
-            "description": "Metro latency from SL to ${metroCode} in ms",
+            "description": "Metro latency from Seoul to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.so_{metroCode}.latency",
-            "description": "Metro latency from SO to ${metroCode} in ms",
+            "description": "Metro latency from Sofia to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sp_{metroCode}.latency",
-            "description": "Metro latency from SP to ${metroCode} in ms",
+            "description": "Metro latency from Sao Paulo to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.st_{metroCode}.latency",
-            "description": "Metro latency from ST to ${metroCode} in ms",
+            "description": "Metro latency from Santiago to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sv_{metroCode}.latency",
-            "description": "Metro latency from SV to ${metroCode} in ms",
+            "description": "Metro latency from Silicon Valley to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sy_{metroCode}.latency",
-            "description": "Metro latency from SY to ${metroCode} in ms",
+            "description": "Metro latency from Sydney to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.tr_{metroCode}.latency",
-            "description": "Metro latency from TR to ${metroCode} in ms",
+            "description": "Metro latency from Toronto to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ty_{metroCode}.latency",
-            "description": "Metro latency from TY to ${metroCode} in ms",
+            "description": "Metro latency from Tokyo to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.va_{metroCode}.latency",
-            "description": "Metro latency from VA to ${metroCode} in ms",
+            "description": "Metro latency from Vancouver to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.wa_{metroCode}.latency",
-            "description": "Metro latency from WA to ${metroCode} in ms",
+            "description": "Metro latency from Warsaw to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.wi_{metroCode}.latency",
-            "description": "Metro latency from WI to ${metroCode} in ms",
+            "description": "Metro latency from Winnipeg to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.zh_{metroCode}.latency",
-            "description": "Metro latency from ZH to ${metroCode} in ms",
+            "description": "Metro latency from Zurich to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         }

--- a/jsonschema/equinix/fabric/v1/MetricEvent.json
+++ b/jsonschema/equinix/fabric/v1/MetricEvent.json
@@ -206,373 +206,373 @@
         },
         {
             "name": "equinix.fabric.metro.am_{metroCode}.latency",
-            "description": "Metro latency from AM to ${metroCode} in ms",
+            "description": "Amsterdam to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.at_{metroCode}.latency",
-            "description": "Metro latency from AT to ${metroCode} in ms",
+            "description": "Atlanta to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ba_{metroCode}.latency",
-            "description": "Metro latency from BA to ${metroCode} in ms",
+            "description": "Barcelona to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.bg_{metroCode}.latency",
-            "description": "Metro latency from BG to ${metroCode} in ms",
+            "description": "Bogota to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.bl_{metroCode}.latency",
-            "description": "Metro latency from BL to ${metroCode} in ms",
+            "description": "Brussels to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.bo_{metroCode}.latency",
-            "description": "Metro latency from BO to ${metroCode} in ms",
+            "description": "Boston to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.bx_{metroCode}.latency",
-            "description": "Metro latency from BX to ${metroCode} in ms",
+            "description": "Bordeaux to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ca_{metroCode}.latency",
-            "description": "Metro latency from CA to ${metroCode} in ms",
+            "description": "Canberra to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ch_{metroCode}.latency",
-            "description": "Metro latency from CH to ${metroCode} in ms",
+            "description": "Chicago to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.cl_{metroCode}.latency",
-            "description": "Metro latency from CL to ${metroCode} in ms",
+            "description": "Calgary to  ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.cu_{metroCode}.latency",
-            "description": "Metro latency from CU to ${metroCode} in ms",
+            "description": "Culpeper to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.da_{metroCode}.latency",
-            "description": "Metro latency from DA to ${metroCode} in ms",
+            "description": "Dallas to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.db_{metroCode}.latency",
-            "description": "Metro latency from DB to ${metroCode} in ms",
+            "description": "Dublin to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.dc_{metroCode}.latency",
-            "description": "Metro latency from DC to ${metroCode} in ms",
+            "description": "Ashburn to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.de_{metroCode}.latency",
-            "description": "Metro latency from DE to ${metroCode} in ms",
+            "description": "Denver to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.dx_{metroCode}.latency",
-            "description": "Metro latency from DX to ${metroCode} in ms",
+            "description": "Dubai to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.fr_{metroCode}.latency",
-            "description": "Metro latency from FR to ${metroCode} in ms",
+            "description": "Frankfurt to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.gv_{metroCode}.latency",
-            "description": "Metro latency from GV to ${metroCode} in ms",
+            "description": "Geneva to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.he_{metroCode}.latency",
-            "description": "Metro latency from HE to ${metroCode} in ms",
+            "description": "Helsinki to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.hh_{metroCode}.latency",
-            "description": "Metro latency from HH to ${metroCode} in ms",
+            "description": "Hamburg to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.hk_{metroCode}.latency",
-            "description": "Metro latency from HK to ${metroCode} in ms",
+            "description": "Hong Kong to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ho_{metroCode}.latency",
-            "description": "Metro latency from HO to ${metroCode} in ms",
+            "description": "Houston to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.il_{metroCode}.latency",
-            "description": "Metro latency from IL to ${metroCode} in ms",
+            "description": "Istanbul to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.jh_{metroCode}.latency",
-            "description": "Metro latency from JH to ${metroCode} in ms",
+            "description": "Johor to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ka_{metroCode}.latency",
-            "description": "Metro latency from KA to ${metroCode} in ms",
+            "description": "Kamloops to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.kl_{metroCode}.latency",
-            "description": "Metro latency from KL to ${metroCode} in ms",
+            "description": "Kuala Lumpur to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.la_{metroCode}.latency",
-            "description": "Metro latency from LA to ${metroCode} in ms",
+            "description": "Los Angeles to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ld_{metroCode}.latency",
-            "description": "Metro latency from LD to ${metroCode} in ms",
+            "description": "London to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.lm_{metroCode}.latency",
-            "description": "Metro latency from LM to ${metroCode} in ms",
+            "description": "Lima to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ls_{metroCode}.latency",
-            "description": "Metro latency from LS to ${metroCode} in ms",
+            "description": "Lisbon to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ma_{metroCode}.latency",
-            "description": "Metro latency from MA to ${metroCode} in ms",
+            "description": "Manchester to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mb_{metroCode}.latency",
-            "description": "Metro latency from MB to ${metroCode} in ms",
+            "description": "Mumbai to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.md_{metroCode}.latency",
-            "description": "Metro latency from MD to ${metroCode} in ms",
+            "description": "Madrid to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.me_{metroCode}.latency",
-            "description": "Metro latency from ME to ${metroCode} in ms",
+            "description": "Melbourne to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mi_{metroCode}.latency",
-            "description": "Metro latency from MI to ${metroCode} in ms",
+            "description": "Miami to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ml_{metroCode}.latency",
-            "description": "Metro latency from ML to ${metroCode} in ms",
+            "description": "Milan to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mo_{metroCode}.latency",
-            "description": "Metro latency from MO to ${metroCode} in ms",
+            "description": "Monterrey to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mt_{metroCode}.latency",
-            "description": "Metro latency from MT to ${metroCode} in ms",
+            "description": "Montreal to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mu_{metroCode}.latency",
-            "description": "Metro latency from MU to ${metroCode} in ms",
+            "description": "Munich to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mx_{metroCode}.latency",
-            "description": "Metro latency from MX to ${metroCode} in ms",
+            "description": "Mexico City to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ny_{metroCode}.latency",
-            "description": "Metro latency from NY to ${metroCode} in ms",
+            "description": "New York to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.os_{metroCode}.latency",
-            "description": "Metro latency from OS to ${metroCode} in ms",
+            "description": "Osaka to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ot_{metroCode}.latency",
-            "description": "Metro latency from OT to ${metroCode} in ms",
+            "description": "Ottawa to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.pa_{metroCode}.latency",
-            "description": "Metro latency from PA to ${metroCode} in ms",
+            "description": "Paris to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.pe_{metroCode}.latency",
-            "description": "Metro latency from PE to ${metroCode} in ms",
+            "description": "Perth to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ph_{metroCode}.latency",
-            "description": "Metro latency from PH to ${metroCode} in ms",
+            "description": "Philadelphia to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.rj_{metroCode}.latency",
-            "description": "Metro latency from RJ to ${metroCode} in ms",
+            "description": "Rio de Janeiro to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.se_{metroCode}.latency",
-            "description": "Metro latency from SE to ${metroCode} in ms",
+            "description": "Seattle to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sg_{metroCode}.latency",
-            "description": "Metro latency from SG to ${metroCode} in ms",
+            "description": "Singapore to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sk_{metroCode}.latency",
-            "description": "Metro latency from SK to ${metroCode} in ms",
+            "description": "Stockholm to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sl_{metroCode}.latency",
-            "description": "Metro latency from SL to ${metroCode} in ms",
+            "description": "Seoul to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.so_{metroCode}.latency",
-            "description": "Metro latency from SO to ${metroCode} in ms",
+            "description": "Sofia to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sp_{metroCode}.latency",
-            "description": "Metro latency from SP to ${metroCode} in ms",
+            "description": "Sao Paulo to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.st_{metroCode}.latency",
-            "description": "Metro latency from ST to ${metroCode} in ms",
+            "description": "Santiago to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sv_{metroCode}.latency",
-            "description": "Metro latency from SV to ${metroCode} in ms",
+            "description": "Silicon Valley to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sy_{metroCode}.latency",
-            "description": "Metro latency from SY to ${metroCode} in ms",
+            "description": "Sydney to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.tr_{metroCode}.latency",
-            "description": "Metro latency from TR to ${metroCode} in ms",
+            "description": "Toronto to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ty_{metroCode}.latency",
-            "description": "Metro latency from TY to ${metroCode} in ms",
+            "description": "Tokyo to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.va_{metroCode}.latency",
-            "description": "Metro latency from VA to ${metroCode} in ms",
+            "description": "Vancouver to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.wa_{metroCode}.latency",
-            "description": "Metro latency from WA to ${metroCode} in ms",
+            "description": "Warsaw to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.wi_{metroCode}.latency",
-            "description": "Metro latency from WI to ${metroCode} in ms",
+            "description": "Winnipeg to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.zh_{metroCode}.latency",
-            "description": "Metro latency from ZH to ${metroCode} in ms",
+            "description": "Zurich to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         }

--- a/jsonschema/equinix/fabric/v1/MetricEvent.json
+++ b/jsonschema/equinix/fabric/v1/MetricEvent.json
@@ -127,8 +127,7 @@
             "name": "equinix.fabric.metric",
             "description": "Metrics collected",
             "sloCategoryCode": "",
-            "inPreview": false,
-            "isReleased": true
+            "releaseStatus": "released"
         }
     ],
     "metricNames": [

--- a/jsonschema/equinix/fabric/v1/MetricEvent.json
+++ b/jsonschema/equinix/fabric/v1/MetricEvent.json
@@ -125,7 +125,7 @@
     "cloudeventTypes": [
         {
             "name": "equinix.fabric.metric",
-            "description": "",
+            "description": "Metrics collected",
             "sloCategoryCode": "",
             "inPreview": false,
             "isReleased": true

--- a/jsonschema/equinix/fabric/v1/MetricEvent.json
+++ b/jsonschema/equinix/fabric/v1/MetricEvent.json
@@ -349,6 +349,18 @@
             "releaseStatus": "released"
         },
         {
+            "name": "equinix.fabric.metro.jk_{metroCode}.latency",
+            "description": "Jakarta to ${metroCode} intermetro latency, average in milliseconds",
+            "sloCategoryCode": "BROWN_METRIC_SLO",
+            "releaseStatus": "released"
+        },
+        {
+            "name": "equinix.fabric.metro.jn_{metroCode}.latency",
+            "description": "Johannesburg to ${metroCode} intermetro latency, average in milliseconds",
+            "sloCategoryCode": "BROWN_METRIC_SLO",
+            "releaseStatus": "released"
+        },
+        {
             "name": "equinix.fabric.metro.ka_{metroCode}.latency",
             "description": "Kamloops to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",

--- a/jsonschema/equinix/fabric/v1/MetricEvent.json
+++ b/jsonschema/equinix/fabric/v1/MetricEvent.json
@@ -206,385 +206,385 @@
         },
         {
             "name": "equinix.fabric.metro.am_{metroCode}.latency",
-            "description": "Amsterdam to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Amsterdam to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.at_{metroCode}.latency",
-            "description": "Atlanta to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Atlanta to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ba_{metroCode}.latency",
-            "description": "Barcelona to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Barcelona to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.bg_{metroCode}.latency",
-            "description": "Bogota to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Bogota to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.bl_{metroCode}.latency",
-            "description": "Brussels to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Brussels to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.bo_{metroCode}.latency",
-            "description": "Boston to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Boston to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.bx_{metroCode}.latency",
-            "description": "Bordeaux to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Bordeaux to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ca_{metroCode}.latency",
-            "description": "Canberra to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Canberra to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ch_{metroCode}.latency",
-            "description": "Chicago to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Chicago to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.cl_{metroCode}.latency",
-            "description": "Calgary to  ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Calgary to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.cu_{metroCode}.latency",
-            "description": "Culpeper to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Culpeper to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.da_{metroCode}.latency",
-            "description": "Dallas to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Dallas to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.db_{metroCode}.latency",
-            "description": "Dublin to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Dublin to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.dc_{metroCode}.latency",
-            "description": "Ashburn to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Ashburn to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.de_{metroCode}.latency",
-            "description": "Denver to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Denver to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.dx_{metroCode}.latency",
-            "description": "Dubai to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Dubai to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.fr_{metroCode}.latency",
-            "description": "Frankfurt to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Frankfurt to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.gv_{metroCode}.latency",
-            "description": "Geneva to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Geneva to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.he_{metroCode}.latency",
-            "description": "Helsinki to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Helsinki to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.hh_{metroCode}.latency",
-            "description": "Hamburg to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Hamburg to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.hk_{metroCode}.latency",
-            "description": "Hong Kong to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Hong Kong to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ho_{metroCode}.latency",
-            "description": "Houston to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Houston to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.il_{metroCode}.latency",
-            "description": "Istanbul to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Istanbul to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.jh_{metroCode}.latency",
-            "description": "Johor to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Johor to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.jk_{metroCode}.latency",
-            "description": "Jakarta to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Jakarta to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.jn_{metroCode}.latency",
-            "description": "Johannesburg to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Johannesburg to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ka_{metroCode}.latency",
-            "description": "Kamloops to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Kamloops to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.kl_{metroCode}.latency",
-            "description": "Kuala Lumpur to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Kuala Lumpur to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.la_{metroCode}.latency",
-            "description": "Los Angeles to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Los Angeles to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ld_{metroCode}.latency",
-            "description": "London to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "London to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.lm_{metroCode}.latency",
-            "description": "Lima to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Lima to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ls_{metroCode}.latency",
-            "description": "Lisbon to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Lisbon to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ma_{metroCode}.latency",
-            "description": "Manchester to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Manchester to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mb_{metroCode}.latency",
-            "description": "Mumbai to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Mumbai to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.md_{metroCode}.latency",
-            "description": "Madrid to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Madrid to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.me_{metroCode}.latency",
-            "description": "Melbourne to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Melbourne to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mi_{metroCode}.latency",
-            "description": "Miami to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Miami to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ml_{metroCode}.latency",
-            "description": "Milan to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Milan to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mo_{metroCode}.latency",
-            "description": "Monterrey to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Monterrey to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mt_{metroCode}.latency",
-            "description": "Montreal to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Montreal to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mu_{metroCode}.latency",
-            "description": "Munich to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Munich to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mx_{metroCode}.latency",
-            "description": "Mexico City to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Mexico City to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ny_{metroCode}.latency",
-            "description": "New York to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "New York to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.os_{metroCode}.latency",
-            "description": "Osaka to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Osaka to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ot_{metroCode}.latency",
-            "description": "Ottawa to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Ottawa to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.pa_{metroCode}.latency",
-            "description": "Paris to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Paris to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.pe_{metroCode}.latency",
-            "description": "Perth to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Perth to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ph_{metroCode}.latency",
-            "description": "Philadelphia to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Philadelphia to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.rj_{metroCode}.latency",
-            "description": "Rio de Janeiro to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Rio de Janeiro to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.se_{metroCode}.latency",
-            "description": "Seattle to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Seattle to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sg_{metroCode}.latency",
-            "description": "Singapore to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Singapore to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sk_{metroCode}.latency",
-            "description": "Stockholm to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Stockholm to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sl_{metroCode}.latency",
-            "description": "Seoul to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Seoul to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.so_{metroCode}.latency",
-            "description": "Sofia to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Sofia to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sp_{metroCode}.latency",
-            "description": "Sao Paulo to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Sao Paulo to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.st_{metroCode}.latency",
-            "description": "Santiago to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Santiago to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sv_{metroCode}.latency",
-            "description": "Silicon Valley to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Silicon Valley to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sy_{metroCode}.latency",
-            "description": "Sydney to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Sydney to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.tr_{metroCode}.latency",
-            "description": "Toronto to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Toronto to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ty_{metroCode}.latency",
-            "description": "Tokyo to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Tokyo to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.va_{metroCode}.latency",
-            "description": "Vancouver to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Vancouver to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.wa_{metroCode}.latency",
-            "description": "Warsaw to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Warsaw to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.wi_{metroCode}.latency",
-            "description": "Winnipeg to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Winnipeg to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.zh_{metroCode}.latency",
-            "description": "Zurich to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Zurich to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         }

--- a/jsonschema/equinix/fabric/v1/MetroLatencyAlert.json
+++ b/jsonschema/equinix/fabric/v1/MetroLatencyAlert.json
@@ -286,6 +286,18 @@
             "releaseStatus": "released"
         },
         {
+            "name": "equinix.fabric.metro.jk_{metroCode}.latency",
+            "description": "Metro latency from Jakarta to ${metroCode} above ${threshold}",
+            "sloCategoryCode": "BLUE_ALERT_SLO",
+            "releaseStatus": "released"
+        },
+        {
+            "name": "equinix.fabric.metro.jn_{metroCode}.latency",
+            "description": "Metro latency from Johannesburg to ${metroCode} above ${threshold}",
+            "sloCategoryCode": "BLUE_ALERT_SLO",
+            "releaseStatus": "released"
+        },
+        {
             "name": "equinix.fabric.metro.ka_{metroCode}.latency",
             "description": "Metro latency from Kamloops to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",

--- a/jsonschema/equinix/fabric/v1/MetroLatencyAlert.json
+++ b/jsonschema/equinix/fabric/v1/MetroLatencyAlert.json
@@ -145,373 +145,373 @@
             "name": "equinix.fabric.metro.am_{metroCode}.latency",
             "description": "Metro latency from Amsterdam to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.at_{metroCode}.latency",
             "description": "Metro latency from Atlanta to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ba_{metroCode}.latency",
             "description": "Metro latency from Barcelona to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.bg_{metroCode}.latency",
             "description": "Metro latency from Bogota to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.bl_{metroCode}.latency",
             "description": "Metro latency from Brussels to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.bo_{metroCode}.latency",
             "description": "Metro latency from Boston to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.bx_{metroCode}.latency",
             "description": "Metro latency from Bordeaux to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ca_{metroCode}.latency",
             "description": "Metro latency from Canberra to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ch_{metroCode}.latency",
             "description": "Metro latency from Chicago to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.cl_{metroCode}.latency",
             "description": "Metro latency from Calgary to  ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.cu_{metroCode}.latency",
             "description": "Metro latency from Culpeper to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.da_{metroCode}.latency",
             "description": "Metro latency from Dallas to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.db_{metroCode}.latency",
             "description": "Metro latency from Dublin to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.dc_{metroCode}.latency",
             "description": "Metro latency from Ashburn to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.de_{metroCode}.latency",
             "description": "Metro latency from Denver to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.dx_{metroCode}.latency",
             "description": "Metro latency from Dubai to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.fr_{metroCode}.latency",
             "description": "Metro latency from Frankfurt to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.gv_{metroCode}.latency",
             "description": "Metro latency from Geneva to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.he_{metroCode}.latency",
             "description": "Metro latency from Helsinki to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.hh_{metroCode}.latency",
             "description": "Metro latency from Hamburg to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.hk_{metroCode}.latency",
             "description": "Metro latency from Hong Kong to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ho_{metroCode}.latency",
             "description": "Metro latency from Houston to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.il_{metroCode}.latency",
             "description": "Metro latency from Istanbul to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.jh_{metroCode}.latency",
             "description": "Metro latency from Johor to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ka_{metroCode}.latency",
             "description": "Metro latency from Kamloops to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.kl_{metroCode}.latency",
             "description": "Metro latency from Kuala Lumpur to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.la_{metroCode}.latency",
             "description": "Metro latency from Los Angeles to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ld_{metroCode}.latency",
             "description": "Metro latency from London to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.lm_{metroCode}.latency",
             "description": "Metro latency from Lima to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ls_{metroCode}.latency",
             "description": "Metro latency from Lisbon to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ma_{metroCode}.latency",
             "description": "Metro latency from Manchester to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mb_{metroCode}.latency",
             "description": "Metro latency from Mumbai to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.md_{metroCode}.latency",
             "description": "Metro latency from Madrid to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.me_{metroCode}.latency",
             "description": "Metro latency from Melbourne to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mi_{metroCode}.latency",
             "description": "Metro latency from Miami to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ml_{metroCode}.latency",
             "description": "Metro latency from Milan to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mo_{metroCode}.latency",
             "description": "Metro latency from Monterrey to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mt_{metroCode}.latency",
             "description": "Metro latency from Montreal to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mu_{metroCode}.latency",
             "description": "Metro latency from Munich to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mx_{metroCode}.latency",
             "description": "Metro latency from Mexico City to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ny_{metroCode}.latency",
             "description": "Metro latency from New York to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.os_{metroCode}.latency",
             "description": "Metro latency from Osaka to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ot_{metroCode}.latency",
             "description": "Metro latency from Ottawa to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.pa_{metroCode}.latency",
             "description": "Metro latency from Paris to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.pe_{metroCode}.latency",
             "description": "Metro latency from Perth to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ph_{metroCode}.latency",
             "description": "Metro latency from Philadelphia to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.rj_{metroCode}.latency",
             "description": "Metro latency from Rio de Janeiro to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.se_{metroCode}.latency",
             "description": "Metro latency from Seattle to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sg_{metroCode}.latency",
             "description": "Metro latency from Singapore to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sk_{metroCode}.latency",
             "description": "Metro latency from Stockholm to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sl_{metroCode}.latency",
             "description": "Metro latency from Seoul to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.so_{metroCode}.latency",
             "description": "Metro latency from Sofia to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sp_{metroCode}.latency",
             "description": "Metro latency from Sao Paulo to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.st_{metroCode}.latency",
             "description": "Metro latency from Santiago to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sv_{metroCode}.latency",
             "description": "Metro latency from Silicon Valley to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sy_{metroCode}.latency",
             "description": "Metro latency from Sydney to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.tr_{metroCode}.latency",
             "description": "Metro latency from Toronto to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ty_{metroCode}.latency",
             "description": "Metro latency from Tokyo to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.va_{metroCode}.latency",
             "description": "Metro latency from Vancouver to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.wa_{metroCode}.latency",
             "description": "Metro latency from Warsaw to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.wi_{metroCode}.latency",
             "description": "Metro latency from Winnipeg to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.zh_{metroCode}.latency",
             "description": "Metro latency from Zurich to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         }
     ]
 }

--- a/jsonschema/equinix/fabric/v1/MetroLatencyAlert.json
+++ b/jsonschema/equinix/fabric/v1/MetroLatencyAlert.json
@@ -138,380 +138,380 @@
             "description": "Schema definition of AlertRule data"
         }
     },
-    "cloudeventTypes": [
+    "cloudeventTypes": [],
+    "metricNames": [],
+    "alertNames": [
         {
             "name": "equinix.fabric.metro.am_{metroCode}.latency",
-            "description": "Metro latency from AM to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Amsterdam to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.at_{metroCode}.latency",
-            "description": "Metro latency from AT to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Atlanta to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.ba_{metroCode}.latency",
-            "description": "Metro latency from BA to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Barcelona to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.bg_{metroCode}.latency",
-            "description": "Metro latency from BG to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Bogota to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.bl_{metroCode}.latency",
-            "description": "Metro latency from BL to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Brussels to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.bo_{metroCode}.latency",
-            "description": "Metro latency from BO to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Boston to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.bx_{metroCode}.latency",
-            "description": "Metro latency from BX to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Bordeaux to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.ca_{metroCode}.latency",
-            "description": "Metro latency from CA to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Canberra to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.ch_{metroCode}.latency",
-            "description": "Metro latency from CH to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Chicago to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.cl_{metroCode}.latency",
-            "description": "Metro latency from CL to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Calgary to  ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.cu_{metroCode}.latency",
-            "description": "Metro latency from CU to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Culpeper to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.da_{metroCode}.latency",
-            "description": "Metro latency from DA to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Dallas to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.db_{metroCode}.latency",
-            "description": "Metro latency from DB to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Dublin to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.dc_{metroCode}.latency",
-            "description": "Metro latency from DC to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Ashburn to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.de_{metroCode}.latency",
-            "description": "Metro latency from DE to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Denver to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.dx_{metroCode}.latency",
-            "description": "Metro latency from DX to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Dubai to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.fr_{metroCode}.latency",
-            "description": "Metro latency from FR to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Frankfurt to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.gv_{metroCode}.latency",
-            "description": "Metro latency from GV to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Geneva to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.he_{metroCode}.latency",
-            "description": "Metro latency from HE to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Helsinki to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.hh_{metroCode}.latency",
-            "description": "Metro latency from HH to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Hamburg to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.hk_{metroCode}.latency",
-            "description": "Metro latency from HK to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Hong Kong to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.ho_{metroCode}.latency",
-            "description": "Metro latency from HO to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Houston to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.il_{metroCode}.latency",
-            "description": "Metro latency from IL to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Istanbul to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.jh_{metroCode}.latency",
-            "description": "Metro latency from JH to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Johor to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.ka_{metroCode}.latency",
-            "description": "Metro latency from KA to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Kamloops to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.kl_{metroCode}.latency",
-            "description": "Metro latency from KL to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Kuala Lumpur to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.la_{metroCode}.latency",
-            "description": "Metro latency from LA to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Los Angeles to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.ld_{metroCode}.latency",
-            "description": "Metro latency from LD to ${metroCode} above ${threshold}",
+            "description": "Metro latency from London to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.lm_{metroCode}.latency",
-            "description": "Metro latency from LM to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Lima to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.ls_{metroCode}.latency",
-            "description": "Metro latency from LS to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Lisbon to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.ma_{metroCode}.latency",
-            "description": "Metro latency from MA to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Manchester to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.mb_{metroCode}.latency",
-            "description": "Metro latency from MB to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Mumbai to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.md_{metroCode}.latency",
-            "description": "Metro latency from MD to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Madrid to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.me_{metroCode}.latency",
-            "description": "Metro latency from ME to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Melbourne to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.mi_{metroCode}.latency",
-            "description": "Metro latency from MI to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Miami to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.ml_{metroCode}.latency",
-            "description": "Metro latency from ML to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Milan to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.mo_{metroCode}.latency",
-            "description": "Metro latency from MO to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Monterrey to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.mt_{metroCode}.latency",
-            "description": "Metro latency from MT to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Montreal to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.mu_{metroCode}.latency",
-            "description": "Metro latency from MU to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Munich to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.mx_{metroCode}.latency",
-            "description": "Metro latency from MX to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Mexico City to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.ny_{metroCode}.latency",
-            "description": "Metro latency from NY to ${metroCode} above ${threshold}",
+            "description": "Metro latency from New York to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.os_{metroCode}.latency",
-            "description": "Metro latency from OS to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Osaka to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.ot_{metroCode}.latency",
-            "description": "Metro latency from OT to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Ottawa to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.pa_{metroCode}.latency",
-            "description": "Metro latency from PA to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Paris to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.pe_{metroCode}.latency",
-            "description": "Metro latency from PE to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Perth to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.ph_{metroCode}.latency",
-            "description": "Metro latency from PH to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Philadelphia to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.rj_{metroCode}.latency",
-            "description": "Metro latency from RJ to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Rio de Janeiro to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.se_{metroCode}.latency",
-            "description": "Metro latency from SE to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Seattle to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.sg_{metroCode}.latency",
-            "description": "Metro latency from SG to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Singapore to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.sk_{metroCode}.latency",
-            "description": "Metro latency from SK to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Stockholm to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.sl_{metroCode}.latency",
-            "description": "Metro latency from SL to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Seoul to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.so_{metroCode}.latency",
-            "description": "Metro latency from SO to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Sofia to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.sp_{metroCode}.latency",
-            "description": "Metro latency from SP to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Sao Paulo to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.st_{metroCode}.latency",
-            "description": "Metro latency from ST to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Santiago to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.sv_{metroCode}.latency",
-            "description": "Metro latency from SV to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Silicon Valley to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.sy_{metroCode}.latency",
-            "description": "Metro latency from SY to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Sydney to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.tr_{metroCode}.latency",
-            "description": "Metro latency from TR to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Toronto to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.ty_{metroCode}.latency",
-            "description": "Metro latency from TY to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Tokyo to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.va_{metroCode}.latency",
-            "description": "Metro latency from VA to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Vancouver to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.wa_{metroCode}.latency",
-            "description": "Metro latency from WA to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Warsaw to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.wi_{metroCode}.latency",
-            "description": "Metro latency from WI to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Winnipeg to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.zh_{metroCode}.latency",
-            "description": "Metro latency from ZH to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Zurich to ${metroCode} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "preview"
         }
-    ],
-    "metricNames": [],
-    "alertNames": []
+    ]
 }

--- a/jsonschema/equinix/fabric/v1/MetroLatencyAlert.json
+++ b/jsonschema/equinix/fabric/v1/MetroLatencyAlert.json
@@ -143,385 +143,385 @@
     "alertNames": [
         {
             "name": "equinix.fabric.metro.am_{metroCode}.latency",
-            "description": "Metro latency from Amsterdam to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Amsterdam to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.at_{metroCode}.latency",
-            "description": "Metro latency from Atlanta to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Atlanta to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ba_{metroCode}.latency",
-            "description": "Metro latency from Barcelona to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Barcelona to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.bg_{metroCode}.latency",
-            "description": "Metro latency from Bogota to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Bogota to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.bl_{metroCode}.latency",
-            "description": "Metro latency from Brussels to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Brussels to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.bo_{metroCode}.latency",
-            "description": "Metro latency from Boston to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Boston to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.bx_{metroCode}.latency",
-            "description": "Metro latency from Bordeaux to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Bordeaux to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ca_{metroCode}.latency",
-            "description": "Metro latency from Canberra to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Canberra to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ch_{metroCode}.latency",
-            "description": "Metro latency from Chicago to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Chicago to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.cl_{metroCode}.latency",
-            "description": "Metro latency from Calgary to  ${metroCode} above ${threshold}",
+            "description": "Metro latency from Calgary to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.cu_{metroCode}.latency",
-            "description": "Metro latency from Culpeper to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Culpeper to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.da_{metroCode}.latency",
-            "description": "Metro latency from Dallas to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Dallas to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.db_{metroCode}.latency",
-            "description": "Metro latency from Dublin to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Dublin to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.dc_{metroCode}.latency",
-            "description": "Metro latency from Ashburn to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Ashburn to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.de_{metroCode}.latency",
-            "description": "Metro latency from Denver to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Denver to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.dx_{metroCode}.latency",
-            "description": "Metro latency from Dubai to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Dubai to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.fr_{metroCode}.latency",
-            "description": "Metro latency from Frankfurt to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Frankfurt to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.gv_{metroCode}.latency",
-            "description": "Metro latency from Geneva to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Geneva to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.he_{metroCode}.latency",
-            "description": "Metro latency from Helsinki to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Helsinki to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.hh_{metroCode}.latency",
-            "description": "Metro latency from Hamburg to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Hamburg to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.hk_{metroCode}.latency",
-            "description": "Metro latency from Hong Kong to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Hong Kong to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ho_{metroCode}.latency",
-            "description": "Metro latency from Houston to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Houston to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.il_{metroCode}.latency",
-            "description": "Metro latency from Istanbul to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Istanbul to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.jh_{metroCode}.latency",
-            "description": "Metro latency from Johor to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Johor to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.jk_{metroCode}.latency",
-            "description": "Metro latency from Jakarta to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Jakarta to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.jn_{metroCode}.latency",
-            "description": "Metro latency from Johannesburg to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Johannesburg to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ka_{metroCode}.latency",
-            "description": "Metro latency from Kamloops to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Kamloops to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.kl_{metroCode}.latency",
-            "description": "Metro latency from Kuala Lumpur to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Kuala Lumpur to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.la_{metroCode}.latency",
-            "description": "Metro latency from Los Angeles to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Los Angeles to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ld_{metroCode}.latency",
-            "description": "Metro latency from London to ${metroCode} above ${threshold}",
+            "description": "Metro latency from London to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.lm_{metroCode}.latency",
-            "description": "Metro latency from Lima to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Lima to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ls_{metroCode}.latency",
-            "description": "Metro latency from Lisbon to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Lisbon to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ma_{metroCode}.latency",
-            "description": "Metro latency from Manchester to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Manchester to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mb_{metroCode}.latency",
-            "description": "Metro latency from Mumbai to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Mumbai to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.md_{metroCode}.latency",
-            "description": "Metro latency from Madrid to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Madrid to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.me_{metroCode}.latency",
-            "description": "Metro latency from Melbourne to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Melbourne to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mi_{metroCode}.latency",
-            "description": "Metro latency from Miami to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Miami to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ml_{metroCode}.latency",
-            "description": "Metro latency from Milan to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Milan to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mo_{metroCode}.latency",
-            "description": "Metro latency from Monterrey to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Monterrey to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mt_{metroCode}.latency",
-            "description": "Metro latency from Montreal to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Montreal to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mu_{metroCode}.latency",
-            "description": "Metro latency from Munich to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Munich to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mx_{metroCode}.latency",
-            "description": "Metro latency from Mexico City to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Mexico City to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ny_{metroCode}.latency",
-            "description": "Metro latency from New York to ${metroCode} above ${threshold}",
+            "description": "Metro latency from New York to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.os_{metroCode}.latency",
-            "description": "Metro latency from Osaka to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Osaka to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ot_{metroCode}.latency",
-            "description": "Metro latency from Ottawa to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Ottawa to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.pa_{metroCode}.latency",
-            "description": "Metro latency from Paris to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Paris to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.pe_{metroCode}.latency",
-            "description": "Metro latency from Perth to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Perth to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ph_{metroCode}.latency",
-            "description": "Metro latency from Philadelphia to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Philadelphia to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.rj_{metroCode}.latency",
-            "description": "Metro latency from Rio de Janeiro to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Rio de Janeiro to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.se_{metroCode}.latency",
-            "description": "Metro latency from Seattle to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Seattle to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sg_{metroCode}.latency",
-            "description": "Metro latency from Singapore to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Singapore to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sk_{metroCode}.latency",
-            "description": "Metro latency from Stockholm to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Stockholm to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sl_{metroCode}.latency",
-            "description": "Metro latency from Seoul to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Seoul to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.so_{metroCode}.latency",
-            "description": "Metro latency from Sofia to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Sofia to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sp_{metroCode}.latency",
-            "description": "Metro latency from Sao Paulo to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Sao Paulo to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.st_{metroCode}.latency",
-            "description": "Metro latency from Santiago to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Santiago to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sv_{metroCode}.latency",
-            "description": "Metro latency from Silicon Valley to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Silicon Valley to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sy_{metroCode}.latency",
-            "description": "Metro latency from Sydney to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Sydney to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.tr_{metroCode}.latency",
-            "description": "Metro latency from Toronto to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Toronto to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ty_{metroCode}.latency",
-            "description": "Metro latency from Tokyo to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Tokyo to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.va_{metroCode}.latency",
-            "description": "Metro latency from Vancouver to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Vancouver to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.wa_{metroCode}.latency",
-            "description": "Metro latency from Warsaw to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Warsaw to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.wi_{metroCode}.latency",
-            "description": "Metro latency from Winnipeg to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Winnipeg to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.zh_{metroCode}.latency",
-            "description": "Metro latency from Zurich to ${metroCode} above ${threshold}",
+            "description": "Metro latency from Zurich to ${metro} above ${threshold}",
             "sloCategoryCode": "BLUE_ALERT_SLO",
             "releaseStatus": "released"
         }

--- a/jsonschema/equinix/fabric/v1/MetroLatencyMetric.json
+++ b/jsonschema/equinix/fabric/v1/MetroLatencyMetric.json
@@ -260,6 +260,18 @@
             "releaseStatus": "released"
         },
         {
+            "name": "equinix.fabric.metro.jk_{metroCode}.latency",
+            "description": "Jakarta to ${metroCode} intermetro latency, average in milliseconds",
+            "sloCategoryCode": "BROWN_METRIC_SLO",
+            "releaseStatus": "released"
+        },
+        {
+            "name": "equinix.fabric.metro.jn_{metroCode}.latency",
+            "description": "Johannesburg to ${metroCode} intermetro latency, average in milliseconds",
+            "sloCategoryCode": "BROWN_METRIC_SLO",
+            "releaseStatus": "released"
+        },
+        {
             "name": "equinix.fabric.metro.ka_{metroCode}.latency",
             "description": "Kamloops to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",

--- a/jsonschema/equinix/fabric/v1/MetroLatencyMetric.json
+++ b/jsonschema/equinix/fabric/v1/MetroLatencyMetric.json
@@ -117,385 +117,385 @@
     "metricNames": [
         {
             "name": "equinix.fabric.metro.am_{metroCode}.latency",
-            "description": "Amsterdam to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Amsterdam to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.at_{metroCode}.latency",
-            "description": "Atlanta to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Atlanta to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ba_{metroCode}.latency",
-            "description": "Barcelona to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Barcelona to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.bg_{metroCode}.latency",
-            "description": "Bogota to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Bogota to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.bl_{metroCode}.latency",
-            "description": "Brussels to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Brussels to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.bo_{metroCode}.latency",
-            "description": "Boston to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Boston to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.bx_{metroCode}.latency",
-            "description": "Bordeaux to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Bordeaux to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ca_{metroCode}.latency",
-            "description": "Canberra to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Canberra to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ch_{metroCode}.latency",
-            "description": "Chicago to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Chicago to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.cl_{metroCode}.latency",
-            "description": "Calgary to  ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Calgary to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.cu_{metroCode}.latency",
-            "description": "Culpeper to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Culpeper to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.da_{metroCode}.latency",
-            "description": "Dallas to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Dallas to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.db_{metroCode}.latency",
-            "description": "Dublin to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Dublin to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.dc_{metroCode}.latency",
-            "description": "Ashburn to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Ashburn to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.de_{metroCode}.latency",
-            "description": "Denver to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Denver to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.dx_{metroCode}.latency",
-            "description": "Dubai to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Dubai to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.fr_{metroCode}.latency",
-            "description": "Frankfurt to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Frankfurt to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.gv_{metroCode}.latency",
-            "description": "Geneva to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Geneva to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.he_{metroCode}.latency",
-            "description": "Helsinki to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Helsinki to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.hh_{metroCode}.latency",
-            "description": "Hamburg to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Hamburg to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.hk_{metroCode}.latency",
-            "description": "Hong Kong to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Hong Kong to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ho_{metroCode}.latency",
-            "description": "Houston to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Houston to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.il_{metroCode}.latency",
-            "description": "Istanbul to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Istanbul to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.jh_{metroCode}.latency",
-            "description": "Johor to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Johor to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.jk_{metroCode}.latency",
-            "description": "Jakarta to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Jakarta to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.jn_{metroCode}.latency",
-            "description": "Johannesburg to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Johannesburg to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ka_{metroCode}.latency",
-            "description": "Kamloops to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Kamloops to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.kl_{metroCode}.latency",
-            "description": "Kuala Lumpur to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Kuala Lumpur to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.la_{metroCode}.latency",
-            "description": "Los Angeles to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Los Angeles to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ld_{metroCode}.latency",
-            "description": "London to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "London to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.lm_{metroCode}.latency",
-            "description": "Lima to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Lima to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ls_{metroCode}.latency",
-            "description": "Lisbon to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Lisbon to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ma_{metroCode}.latency",
-            "description": "Manchester to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Manchester to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mb_{metroCode}.latency",
-            "description": "Mumbai to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Mumbai to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.md_{metroCode}.latency",
-            "description": "Madrid to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Madrid to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.me_{metroCode}.latency",
-            "description": "Melbourne to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Melbourne to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mi_{metroCode}.latency",
-            "description": "Miami to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Miami to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ml_{metroCode}.latency",
-            "description": "Milan to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Milan to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mo_{metroCode}.latency",
-            "description": "Monterrey to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Monterrey to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mt_{metroCode}.latency",
-            "description": "Montreal to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Montreal to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mu_{metroCode}.latency",
-            "description": "Munich to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Munich to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mx_{metroCode}.latency",
-            "description": "Mexico City to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Mexico City to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ny_{metroCode}.latency",
-            "description": "New York to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "New York to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.os_{metroCode}.latency",
-            "description": "Osaka to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Osaka to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ot_{metroCode}.latency",
-            "description": "Ottawa to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Ottawa to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.pa_{metroCode}.latency",
-            "description": "Paris to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Paris to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.pe_{metroCode}.latency",
-            "description": "Perth to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Perth to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ph_{metroCode}.latency",
-            "description": "Philadelphia to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Philadelphia to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.rj_{metroCode}.latency",
-            "description": "Rio de Janeiro to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Rio de Janeiro to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.se_{metroCode}.latency",
-            "description": "Seattle to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Seattle to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sg_{metroCode}.latency",
-            "description": "Singapore to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Singapore to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sk_{metroCode}.latency",
-            "description": "Stockholm to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Stockholm to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sl_{metroCode}.latency",
-            "description": "Seoul to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Seoul to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.so_{metroCode}.latency",
-            "description": "Sofia to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Sofia to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sp_{metroCode}.latency",
-            "description": "Sao Paulo to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Sao Paulo to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.st_{metroCode}.latency",
-            "description": "Santiago to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Santiago to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sv_{metroCode}.latency",
-            "description": "Silicon Valley to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Silicon Valley to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sy_{metroCode}.latency",
-            "description": "Sydney to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Sydney to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.tr_{metroCode}.latency",
-            "description": "Toronto to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Toronto to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ty_{metroCode}.latency",
-            "description": "Tokyo to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Tokyo to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.va_{metroCode}.latency",
-            "description": "Vancouver to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Vancouver to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.wa_{metroCode}.latency",
-            "description": "Warsaw to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Warsaw to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.wi_{metroCode}.latency",
-            "description": "Winnipeg to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Winnipeg to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.zh_{metroCode}.latency",
-            "description": "Zurich to ${metroCode} intermetro latency, average in milliseconds",
+            "description": "Zurich to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         }

--- a/jsonschema/equinix/fabric/v1/MetroLatencyMetric.json
+++ b/jsonschema/equinix/fabric/v1/MetroLatencyMetric.json
@@ -109,7 +109,7 @@
     "cloudeventTypes": [
         {
             "name": "equinix.fabric.metric",
-            "description": "",
+            "description": "Metrics collected",
             "sloCategoryCode": "",
             "releaseStatus": "released"
         }

--- a/jsonschema/equinix/fabric/v1/MetroLatencyMetric.json
+++ b/jsonschema/equinix/fabric/v1/MetroLatencyMetric.json
@@ -117,373 +117,373 @@
     "metricNames": [
         {
             "name": "equinix.fabric.metro.am_{metroCode}.latency",
-            "description": "Metro latency from AM to ${metroCode} in ms",
+            "description": "Amsterdam to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.at_{metroCode}.latency",
-            "description": "Metro latency from AT to ${metroCode} in ms",
+            "description": "Atlanta to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ba_{metroCode}.latency",
-            "description": "Metro latency from BA to ${metroCode} in ms",
+            "description": "Barcelona to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.bg_{metroCode}.latency",
-            "description": "Metro latency from BG to ${metroCode} in ms",
+            "description": "Bogota to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.bl_{metroCode}.latency",
-            "description": "Metro latency from BL to ${metroCode} in ms",
+            "description": "Brussels to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.bo_{metroCode}.latency",
-            "description": "Metro latency from BO to ${metroCode} in ms",
+            "description": "Boston to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.bx_{metroCode}.latency",
-            "description": "Metro latency from BX to ${metroCode} in ms",
+            "description": "Bordeaux to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ca_{metroCode}.latency",
-            "description": "Metro latency from CA to ${metroCode} in ms",
+            "description": "Canberra to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ch_{metroCode}.latency",
-            "description": "Metro latency from CH to ${metroCode} in ms",
+            "description": "Chicago to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.cl_{metroCode}.latency",
-            "description": "Metro latency from CL to ${metroCode} in ms",
+            "description": "Calgary to  ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.cu_{metroCode}.latency",
-            "description": "Metro latency from CU to ${metroCode} in ms",
+            "description": "Culpeper to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.da_{metroCode}.latency",
-            "description": "Metro latency from DA to ${metroCode} in ms",
+            "description": "Dallas to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.db_{metroCode}.latency",
-            "description": "Metro latency from DB to ${metroCode} in ms",
+            "description": "Dublin to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.dc_{metroCode}.latency",
-            "description": "Metro latency from DC to ${metroCode} in ms",
+            "description": "Ashburn to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.de_{metroCode}.latency",
-            "description": "Metro latency from DE to ${metroCode} in ms",
+            "description": "Denver to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.dx_{metroCode}.latency",
-            "description": "Metro latency from DX to ${metroCode} in ms",
+            "description": "Dubai to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.fr_{metroCode}.latency",
-            "description": "Metro latency from FR to ${metroCode} in ms",
+            "description": "Frankfurt to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.gv_{metroCode}.latency",
-            "description": "Metro latency from GV to ${metroCode} in ms",
+            "description": "Geneva to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.he_{metroCode}.latency",
-            "description": "Metro latency from HE to ${metroCode} in ms",
+            "description": "Helsinki to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.hh_{metroCode}.latency",
-            "description": "Metro latency from HH to ${metroCode} in ms",
+            "description": "Hamburg to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.hk_{metroCode}.latency",
-            "description": "Metro latency from HK to ${metroCode} in ms",
+            "description": "Hong Kong to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ho_{metroCode}.latency",
-            "description": "Metro latency from HO to ${metroCode} in ms",
+            "description": "Houston to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.il_{metroCode}.latency",
-            "description": "Metro latency from IL to ${metroCode} in ms",
+            "description": "Istanbul to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.jh_{metroCode}.latency",
-            "description": "Metro latency from JH to ${metroCode} in ms",
+            "description": "Johor to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ka_{metroCode}.latency",
-            "description": "Metro latency from KA to ${metroCode} in ms",
+            "description": "Kamloops to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.kl_{metroCode}.latency",
-            "description": "Metro latency from KL to ${metroCode} in ms",
+            "description": "Kuala Lumpur to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.la_{metroCode}.latency",
-            "description": "Metro latency from LA to ${metroCode} in ms",
+            "description": "Los Angeles to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ld_{metroCode}.latency",
-            "description": "Metro latency from LD to ${metroCode} in ms",
+            "description": "London to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.lm_{metroCode}.latency",
-            "description": "Metro latency from LM to ${metroCode} in ms",
+            "description": "Lima to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ls_{metroCode}.latency",
-            "description": "Metro latency from LS to ${metroCode} in ms",
+            "description": "Lisbon to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ma_{metroCode}.latency",
-            "description": "Metro latency from MA to ${metroCode} in ms",
+            "description": "Manchester to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mb_{metroCode}.latency",
-            "description": "Metro latency from MB to ${metroCode} in ms",
+            "description": "Mumbai to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.md_{metroCode}.latency",
-            "description": "Metro latency from MD to ${metroCode} in ms",
+            "description": "Madrid to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.me_{metroCode}.latency",
-            "description": "Metro latency from ME to ${metroCode} in ms",
+            "description": "Melbourne to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mi_{metroCode}.latency",
-            "description": "Metro latency from MI to ${metroCode} in ms",
+            "description": "Miami to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ml_{metroCode}.latency",
-            "description": "Metro latency from ML to ${metroCode} in ms",
+            "description": "Milan to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mo_{metroCode}.latency",
-            "description": "Metro latency from MO to ${metroCode} in ms",
+            "description": "Monterrey to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mt_{metroCode}.latency",
-            "description": "Metro latency from MT to ${metroCode} in ms",
+            "description": "Montreal to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mu_{metroCode}.latency",
-            "description": "Metro latency from MU to ${metroCode} in ms",
+            "description": "Munich to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.mx_{metroCode}.latency",
-            "description": "Metro latency from MX to ${metroCode} in ms",
+            "description": "Mexico City to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ny_{metroCode}.latency",
-            "description": "Metro latency from NY to ${metroCode} in ms",
+            "description": "New York to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.os_{metroCode}.latency",
-            "description": "Metro latency from OS to ${metroCode} in ms",
+            "description": "Osaka to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ot_{metroCode}.latency",
-            "description": "Metro latency from OT to ${metroCode} in ms",
+            "description": "Ottawa to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.pa_{metroCode}.latency",
-            "description": "Metro latency from PA to ${metroCode} in ms",
+            "description": "Paris to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.pe_{metroCode}.latency",
-            "description": "Metro latency from PE to ${metroCode} in ms",
+            "description": "Perth to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ph_{metroCode}.latency",
-            "description": "Metro latency from PH to ${metroCode} in ms",
+            "description": "Philadelphia to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.rj_{metroCode}.latency",
-            "description": "Metro latency from RJ to ${metroCode} in ms",
+            "description": "Rio de Janeiro to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.se_{metroCode}.latency",
-            "description": "Metro latency from SE to ${metroCode} in ms",
+            "description": "Seattle to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sg_{metroCode}.latency",
-            "description": "Metro latency from SG to ${metroCode} in ms",
+            "description": "Singapore to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sk_{metroCode}.latency",
-            "description": "Metro latency from SK to ${metroCode} in ms",
+            "description": "Stockholm to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sl_{metroCode}.latency",
-            "description": "Metro latency from SL to ${metroCode} in ms",
+            "description": "Seoul to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.so_{metroCode}.latency",
-            "description": "Metro latency from SO to ${metroCode} in ms",
+            "description": "Sofia to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sp_{metroCode}.latency",
-            "description": "Metro latency from SP to ${metroCode} in ms",
+            "description": "Sao Paulo to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.st_{metroCode}.latency",
-            "description": "Metro latency from ST to ${metroCode} in ms",
+            "description": "Santiago to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sv_{metroCode}.latency",
-            "description": "Metro latency from SV to ${metroCode} in ms",
+            "description": "Silicon Valley to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.sy_{metroCode}.latency",
-            "description": "Metro latency from SY to ${metroCode} in ms",
+            "description": "Sydney to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.tr_{metroCode}.latency",
-            "description": "Metro latency from TR to ${metroCode} in ms",
+            "description": "Toronto to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.ty_{metroCode}.latency",
-            "description": "Metro latency from TY to ${metroCode} in ms",
+            "description": "Tokyo to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.va_{metroCode}.latency",
-            "description": "Metro latency from VA to ${metroCode} in ms",
+            "description": "Vancouver to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.wa_{metroCode}.latency",
-            "description": "Metro latency from WA to ${metroCode} in ms",
+            "description": "Warsaw to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.wi_{metroCode}.latency",
-            "description": "Metro latency from WI to ${metroCode} in ms",
+            "description": "Winnipeg to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.metro.zh_{metroCode}.latency",
-            "description": "Metro latency from ZH to ${metroCode} in ms",
+            "description": "Zurich to ${metroCode} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
             "releaseStatus": "released"
         }

--- a/jsonschema/equinix/identity/v1/UserOrgLinkageEvent.json
+++ b/jsonschema/equinix/identity/v1/UserOrgLinkageEvent.json
@@ -26,13 +26,13 @@
       "name": "equinix.identity.organization.user.added",
       "description": "User added to org event",
       "sloCategoryCode": "BLUE_EVENT_SLO",
-      "releaseStatus": "preview"
+      "releaseStatus": "released"
     },
     {
       "name": "equinix.identity.organization.user.removed",
       "description": "User removed from org event",
       "sloCategoryCode": "BLUE_EVENT_SLO",
-      "releaseStatus": "preview"
+      "releaseStatus": "released"
     }
   ],
   "metricNames": [],

--- a/scripts/update_data_loader.py
+++ b/scripts/update_data_loader.py
@@ -11,7 +11,7 @@ def retrieve_supported_events():
     dataLoaderStructure = {}
     for root, dirs, files in os.walk(directory):
         for file in files:
-            if file.endswith('.json') and os.path.basename(root) != "jsonschema" and "MetroLatency" not in file:
+            if file.endswith('.json') and os.path.basename(root) != "jsonschema":
                 with open(root + "/" + file, "r") as eventFile:
                     data = json.load(eventFile)
 

--- a/scripts/update_data_loader.py
+++ b/scripts/update_data_loader.py
@@ -13,8 +13,13 @@ def retrieve_supported_events():
         for file in files:
             if file.endswith('.json') and os.path.basename(root) != "jsonschema" and "MetroLatency" not in file:
                 with open(root + "/" + file, "r") as eventFile:
-                    domain = root.split("/")[-2]
                     data = json.load(eventFile)
+
+                    # Skip processing if domain contains "Deprecated"
+                    if "domain" in data and "deprecated" in data["domain"].lower():
+                        continue
+
+                    domain = root.split("/")[-2]
                     if domain not in dataLoaderStructure:
                         dataLoaderStructure[domain] = {
                             sc.EVENTS:  [],

--- a/scripts/update_data_loader.py
+++ b/scripts/update_data_loader.py
@@ -11,7 +11,7 @@ def retrieve_supported_events():
     dataLoaderStructure = {}
     for root, dirs, files in os.walk(directory):
         for file in files:
-            if file.endswith('.json') and os.path.basename(root) != "jsonschema":
+            if file.endswith('.json') and os.path.basename(root) != "jsonschema" and "MetroLatency" not in file:
                 with open(root + "/" + file, "r") as eventFile:
                     domain = root.split("/")[-2]
                     data = json.load(eventFile)


### PR DESCRIPTION
## Checklist
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I certify that my `preview` and `released` lists for Events/Metrics/Alerts are correct
- [x] I certify that all Events/Metrics/Alerts in `released` are properly tested and ready for production

## Changes
- updated dataloader python script to ignore `MetroLatency*` files, because there were duplicate values in dataloader.json for the metro latency metrics and alerts
- updated the following ALERTS to "released":
```
equinix.fabric.metro.*_{metroCode}.latency
equinix.fabric.connection.bandwidth_rx.usage
equinix.fabric.connection.bandwidth_tx.usage
equinix.fabric.port.bandwidth_rx.usage
equinix.fabric.port.bandwidth_tx.usage
equinix.fabric.port.packets_erred_rx.count
equinix.fabric.port.packets_erred_tx.count
equinix.fabric.port.packets_dropped_rx.count
equinix.fabric.port.packets_dropped_tx.count
```
- in MetroLatencyAlert.json , move the alerts from the events section to the alerts section
- Add missing metros: JK and JN
- Update Alert descriptions to be adaptable for both alert `raise` and `lower` messages
- example: `Metro latency from Perth to ${metroCode} is ${operator} ${operand} milliseconds` translates to 
  - `Metro latency from Perth to Amsterdam is ABOVE 150 milliseconds` for RAISE
  - `Metro latency from Perth to Amsterdam is 50 milliseconds` for CLEAR
