### PR TITLE
CXF-114052: Register new cloud event types for Fabric Physical Port state changes

### DIFF
--- a/DataLoader.json
+++ b/DataLoader.json
@@ -593,6 +593,36 @@
                 "releaseStatus": "released"
             },
             {
+                "name": "equinix.fabric.physical_port.state.deprovisioned",
+                "description": "Physical port ${port_id} state changed to deprovisioned",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.physical_port.state.deprovisioning",
+                "description": "Physical port ${port_id} state changed to deprovisioning",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.physical_port.state.failed",
+                "description": "Physical port ${port_id} state changed to failed",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.physical_port.state.pending_cross_connect",
+                "description": "Physical port ${port_id} state changed to pending_cross_connect",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.physical_port.state.provisioned",
+                "description": "Physical port ${port_id} state changed to provisioned",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.physical_port.state.provisioning",
+                "description": "Physical port ${port_id} state changed to provisioning",
+                "releaseStatus": "preview"
+            },
+            {
                 "name": "equinix.fabric.route_aggregation.attribute.changed",
                 "description": "Route Aggregation named ${route_aggregation_name} attribute changed",
                 "releaseStatus": "preview"

--- a/README.md
+++ b/README.md
@@ -466,6 +466,42 @@ The following data payloads are the supported events and formats for Equinix Net
 		<td>released</td>
 	<td><a href='#purple_event_slo'> <span style='color:purple'>PURPLE_EVENT_SLO</span></a></td>
 	</tr>
+    <tr>
+		<td>equinix.fabric.physical_port.state.provisioning</td>
+		<td>Physical port ${port_id} state changed to provisioning</td>
+		<td>preview</td>
+	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
+	</tr>
+    <tr>
+		<td>equinix.fabric.physical_port.state.pending_cross_connect</td>
+		<td>Physical port ${port_id} state changed to pending_cross_connect</td>
+		<td>preview</td>
+	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
+	</tr>
+    <tr>
+		<td>equinix.fabric.physical_port.state.provisioned</td>
+		<td>Physical port ${port_id} state changed to provisioned</td>
+		<td>preview</td>
+	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
+	</tr>
+    <tr>
+		<td>equinix.fabric.physical_port.state.deprovisioning</td>
+		<td>Physical port ${port_id} state changed to deprovisioning</td>
+		<td>preview</td>
+	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
+	</tr>
+    <tr>
+		<td>equinix.fabric.physical_port.state.deprovisioned</td>
+		<td>Physical port ${port_id} state changed to deprovisioned</td>
+		<td>preview</td>
+	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
+	</tr>
+    <tr>
+		<td>equinix.fabric.physical_port.state.failed</td>
+		<td>Physical port ${port_id} state changed to failed</td>
+		<td>preview</td>
+	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
+	</tr>
 	<tr>
 		<td>equinix.fabric.route_aggregation.attribute.changed</td>
 		<td>Route Aggregation named ${route_aggregation_name} attribute changed</td>

--- a/README.md
+++ b/README.md
@@ -413,6 +413,42 @@ The following data payloads are the supported events and formats for Equinix Net
 	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
 	</tr>
 	<tr>
+		<td>equinix.fabric.physical_port.state.deprovisioned</td>
+		<td>Physical port ${port_id} state changed to deprovisioned</td>
+		<td>preview</td>
+	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
+	</tr>
+	<tr>
+		<td>equinix.fabric.physical_port.state.deprovisioning</td>
+		<td>Physical port ${port_id} state changed to deprovisioning</td>
+		<td>preview</td>
+	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
+	</tr>
+	<tr>
+		<td>equinix.fabric.physical_port.state.failed</td>
+		<td>Physical port ${port_id} state changed to failed</td>
+		<td>preview</td>
+	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
+	</tr>
+	<tr>
+		<td>equinix.fabric.physical_port.state.pending_cross_connect</td>
+		<td>Physical port ${port_id} state changed to pending_cross_connect</td>
+		<td>preview</td>
+	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
+	</tr>
+	<tr>
+		<td>equinix.fabric.physical_port.state.provisioned</td>
+		<td>Physical port ${port_id} state changed to provisioned</td>
+		<td>preview</td>
+	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
+	</tr>
+	<tr>
+		<td>equinix.fabric.physical_port.state.provisioning</td>
+		<td>Physical port ${port_id} state changed to provisioning</td>
+		<td>preview</td>
+	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
+	</tr>
+	<tr>
 		<td>equinix.fabric.port.state.deprovisioned</td>
 		<td>Virtual port named ${port_name} state changed to deprovisioned</td>
 		<td>released</td>
@@ -465,42 +501,6 @@ The following data payloads are the supported events and formats for Equinix Net
 		<td>Virtual|Physical port '${port_name}' status changed to UP</td>
 		<td>released</td>
 	<td><a href='#purple_event_slo'> <span style='color:purple'>PURPLE_EVENT_SLO</span></a></td>
-	</tr>
-    <tr>
-		<td>equinix.fabric.physical_port.state.provisioning</td>
-		<td>Physical port ${port_id} state changed to provisioning</td>
-		<td>preview</td>
-	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
-	</tr>
-    <tr>
-		<td>equinix.fabric.physical_port.state.pending_cross_connect</td>
-		<td>Physical port ${port_id} state changed to pending_cross_connect</td>
-		<td>preview</td>
-	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
-	</tr>
-    <tr>
-		<td>equinix.fabric.physical_port.state.provisioned</td>
-		<td>Physical port ${port_id} state changed to provisioned</td>
-		<td>preview</td>
-	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
-	</tr>
-    <tr>
-		<td>equinix.fabric.physical_port.state.deprovisioning</td>
-		<td>Physical port ${port_id} state changed to deprovisioning</td>
-		<td>preview</td>
-	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
-	</tr>
-    <tr>
-		<td>equinix.fabric.physical_port.state.deprovisioned</td>
-		<td>Physical port ${port_id} state changed to deprovisioned</td>
-		<td>preview</td>
-	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
-	</tr>
-    <tr>
-		<td>equinix.fabric.physical_port.state.failed</td>
-		<td>Physical port ${port_id} state changed to failed</td>
-		<td>preview</td>
-	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.route_aggregation.attribute.changed</td>

--- a/jsonschema/catalog.json
+++ b/jsonschema/catalog.json
@@ -351,6 +351,42 @@
                     "releaseStatus": "released"
                 },
                 {
+                    "name": "equinix.fabric.physical_port.state.deprovisioned",
+                    "description": "Physical port ${port_id} state changed to deprovisioned",
+                    "sloCategoryCode": "BLUE_EVENT_SLO",
+                    "releaseStatus": "preview"
+                },
+                {
+                    "name": "equinix.fabric.physical_port.state.deprovisioning",
+                    "description": "Physical port ${port_id} state changed to deprovisioning",
+                    "sloCategoryCode": "BLUE_EVENT_SLO",
+                    "releaseStatus": "preview"
+                },
+                {
+                    "name": "equinix.fabric.physical_port.state.failed",
+                    "description": "Physical port ${port_id} state changed to failed",
+                    "sloCategoryCode": "BLUE_EVENT_SLO",
+                    "releaseStatus": "preview"
+                },
+                {
+                    "name": "equinix.fabric.physical_port.state.pending_cross_connect",
+                    "description": "Physical port ${port_id} state changed to pending_cross_connect",
+                    "sloCategoryCode": "BLUE_EVENT_SLO",
+                    "releaseStatus": "preview"
+                },
+                {
+                    "name": "equinix.fabric.physical_port.state.provisioned",
+                    "description": "Physical port ${port_id} state changed to provisioned",
+                    "sloCategoryCode": "BLUE_EVENT_SLO",
+                    "releaseStatus": "preview"
+                },
+                {
+                    "name": "equinix.fabric.physical_port.state.provisioning",
+                    "description": "Physical port ${port_id} state changed to provisioning",
+                    "sloCategoryCode": "BLUE_EVENT_SLO",
+                    "releaseStatus": "preview"
+                },
+                {
                     "name": "equinix.fabric.port.state.deprovisioned",
                     "description": "Virtual port named ${port_name} state changed to deprovisioned",
                     "sloCategoryCode": "BLUE_EVENT_SLO",

--- a/jsonschema/equinix/fabric/v1/ChangeEvent.json
+++ b/jsonschema/equinix/fabric/v1/ChangeEvent.json
@@ -374,6 +374,42 @@
             "releaseStatus": "released"
         },
         {
+            "name": "equinix.fabric.physical_port.state.provisioning",
+            "description": "Physical port ${port_id} state changed to provisioning",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.physical_port.state.pending_cross_connect",
+            "description": "Physical port ${port_id} state changed to pending_cross_connect",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.physical_port.state.provisioned",
+            "description": "Physical port ${port_id} state changed to provisioned",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.physical_port.state.deprovisioning",
+            "description": "Physical port ${port_id} state changed to deprovisioning",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.physical_port.state.deprovisioned",
+            "description": "Physical port ${port_id} state changed to deprovisioned",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.physical_port.state.failed",
+            "description": "Physical port ${port_id} state changed to failed",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        },
+        {
             "name": "equinix.fabric.router.state.provisioning",
             "description": "Router named ${router_name} state changed to provisioning",
             "sloCategoryCode": "BLUE_EVENT_SLO",


### PR DESCRIPTION


## Checklist
- [X] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I certify that my `preview` and `released` lists for Events/Metrics/Alerts are correct
- [ ] I certify that all Events/Metrics/Alerts in `released` are properly tested and ready for production
