### PR TITLE
Add new STS token-issued event

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,3 +7,4 @@ resource_manager* @equinix/governor-qore-crh
 access_manager* @equinix/governor-qore-crh
 network_edge* @equinix/governor-ne-network-edge-engineering
 platform_identity* @equinix/governor-qore-identity
+iam* @equinixmetal/governor-metal-equinix-watch

--- a/jsonschema/equinix/iam/v1/TokenIssuedEvent.json
+++ b/jsonschema/equinix/iam/v1/TokenIssuedEvent.json
@@ -1,0 +1,125 @@
+{
+    "$id": "https://equinix.github.io/equinix-cloudevents/jsonschema/equinix/iam/v1/TokenIssuedEvent.json",
+    "title": "TokenIssuedEvent",
+    "examples": [],
+    "package": "equinix.iam.v1",
+    "datatype": "equinix.iam.v1.TokenIssuedEvent",
+    "domain": "Equinix IAM TokenIssuedEvent",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "#/definitions/Data",
+    "definitions": {
+        "Data": {
+            "type": "object",
+            "title": "TokenIssued event data",
+            "properties": {
+                "message": {
+                    "type": "string"
+                },
+                "resource": { "$ref": "#/definitions/Resource" },
+                "auth": { "$ref": "#/definitions/Auth" }
+            },
+            "required": [ "message", "resource", "auth" ],
+            "additionalProperties": true
+        },
+        "Resource": {
+            "type": "object",
+            "title": "TokenIssued resource definition",
+            "description": "Provides detailed information about the token issuance",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "The identifier of the principal to whom the token was issued"
+                },
+                "token": { "$ref": "#/definitions/Token" }
+            },
+            "required": [ "id", "token" ],
+            "additionalProperties": true
+        },
+        "Auth": {
+            "type": "object",
+            "title": "Auth context",
+            "description": "Authentication context for the token issuance",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "The unique identifier of the authenticated principal."
+                },
+                "type": {
+                    "type": "string",
+                    "description": "The type of authenticated principal."
+                }
+            },
+            "required": [ "id", "type" ],
+            "additionalProperties": true
+        },
+        "Token": {
+            "type": "object",
+            "title": "Token",
+            "description": "Details about the token that was issued.",
+            "properties": {
+                "scope": {
+                    "type": "string",
+                    "description": "The scope of access that was requested for the token"
+                },
+                "claims": { "$ref": "#/definitions/Claims" }
+            },
+            "required": [ "scope", "claims" ],
+            "additionalProperties": true
+        },
+        "Claims": {
+            "type": "object",
+            "title": "Claims",
+            "description": "Details about the JWT claims in the issued token.",
+            "properties": {
+                "iss": {
+                    "type": "string",
+                    "description": "URI of the token issuer"
+                },
+                "aud": {
+                    "type": "string",
+                    "description": "The access token audience"
+                },
+                "sub": {
+                    "type": "string",
+                    "description": "The principal that is the subject of the access token"
+                },
+                "iat": {
+                    "type": "integer",
+                    "description": "Timestamp when the token was issued, in Unix epoch milliseconds"
+                },
+                "exp": {
+                    "type": "integer",
+                    "description": "Expiration time for the token, in Unix epoch milliseconds"
+                },
+                "equinix.com/scope_type": {
+                    "enum": [ "accesspolicy", "roleassignments" ],
+                    "description": "Indicates whether the scope of access is tied to an access policy or the principal's role assignments."
+                },
+                "equinix.com/access_policy_ern": {
+                    "type": "string",
+                    "description": "For access-policy scoped tokens, the ERN of the access policy that will be used for authorization decisions."
+                },
+                "equinix.com/org": {
+                    "type": "string",
+                    "description": "For role-assignment scoped tokens, the organization ID in which access is granted."
+                },
+                "equinix.com/cust_org": {
+                    "type": "string",
+                    "description": "For role-assignment scoped tokens, the cust-org ID in which access is granted."
+                }
+            },
+            "required": [ "iss", "aud", "sub", "iat", "exp" ],
+            "additionalProperties": true
+        }
+    },
+    "cloudeventTypes": [
+        {
+            "name": "equinix.iam.principal.token.issued",
+            "description": "Access token issued to principal ${principal_id}",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        }
+    ],
+    "metricNames": [],
+    "alertNames": []
+}


### PR DESCRIPTION
## Sample Event

```
specversion: '1.0'
source: 'service:equinix/sts'
id: 5272fd70-15e1-46c1-83af-4b1025e85eb3
type: equinix.iam.principal.token.issued
time: '2025-06-25T14:27:44.576Z'
severitytext: INFO
severitynumber: 9
equinixproject: 15a3d5e1-4974-4c7b-9a64-e2ab3d137401
equinixorganization: /15a3d5e1-4974-4c7b-9a64-e2ab3d137401
datacontenttype: application/json
datascheme: https://equinix.github.io/equinix-cloudevents/jsonschema/equinix/identity/v1/AuditEvent.json
subject: "principal:15a3d5e1-4974-4c7b-9a64-e2ab3d137401:okta-QQ47A5:00u61stiwref6D2rO697"
authtype: federated
authid: principal:15a3d5e1-4974-4c7b-9a64-e2ab3d137401:okta-QQ47A5:00u61stiwref6D2rO697
data:
  message: "Access token issued to principal 'principal:15a3d5e1-4974-4c7b-9a64-e2ab3d137401:okta-QQ47A5:00u61stiwref6D2rO697' for access policy 'ern:uat:equinix/access:global:15a3d5e1-4974-4c7b-9a64-e2ab3d137401:AccessPolicy:admin'"
  resource:  # it seems that the resource should be the token (or claim)
    id: principal:15a3d5e1-4974-4c7b-9a64-e2ab3d137401:okta-QQ47A5:00u61stiwref6D2rO697
    token:
      scope: ern:uat:equinix/access:global:15a3d5e1-4974-4c7b-9a64-e2ab3d137401:AccessPolicy:admin
      claims:
        iss: 'https://sts.uat.equinix.com'
        aud: 'cloud:uat'
        sub: principal:15a3d5e1-4974-4c7b-9a64-e2ab3d137401:okta-QQ47A5:00u61stiwref6D2rO697
        iat: 1750861664
        exp: 1750865264
        equinix.com/scope_type: accesspolicy
        equinix.com/access_policy_ern: ern:uat:equinix/access:global:15a3d5e1-4974-4c7b-9a64-e2ab3d137401:AccessPolicy:admin
  auth:
    id: principal:15a3d5e1-4974-4c7b-9a64-e2ab3d137401:okta-QQ47A5:00u61stiwref6D2rO697
    type: federated
```

## NOTES

- In `preview` status, we will publish with a subject type of "Project", e.g. `/resourceManager/v2/projects/15a3d5e1-4974-4c7b-9a64-e2ab3d137401`, in order to make these events routable so we can test the end-to-end events flow. We will update to send with principal as the subject once support for this is complete in DIGIN Observability.

## Checklist
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I certify that my `preview` and `released` lists for Events/Metrics/Alerts are correct
- [x] I certify that all Events/Metrics/Alerts in `released` are properly tested and ready for production
