### PR TITLE
CXF-114052: Fabric Physical Port state change events - mark as released

### DIFF
--- a/DataLoader.json
+++ b/DataLoader.json
@@ -645,32 +645,32 @@
             {
                 "name": "equinix.fabric.physical_port.state.deprovisioned",
                 "description": "Physical port ${port_id} state changed to deprovisioned",
-                "releaseStatus": "preview"
+                "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.physical_port.state.deprovisioning",
                 "description": "Physical port ${port_id} state changed to deprovisioning",
-                "releaseStatus": "preview"
+                "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.physical_port.state.failed",
                 "description": "Physical port ${port_id} state changed to failed",
-                "releaseStatus": "preview"
+                "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.physical_port.state.pending_cross_connect",
                 "description": "Physical port ${port_id} state changed to pending_cross_connect",
-                "releaseStatus": "preview"
+                "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.physical_port.state.provisioned",
                 "description": "Physical port ${port_id} state changed to provisioned",
-                "releaseStatus": "preview"
+                "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.physical_port.state.provisioning",
                 "description": "Physical port ${port_id} state changed to provisioning",
-                "releaseStatus": "preview"
+                "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.route_aggregation.attribute.changed",

--- a/DataLoader.json
+++ b/DataLoader.json
@@ -288,6 +288,36 @@
                 "releaseStatus": "released"
             },
             {
+                "name": "equinix.fabric.physical_port.state.deprovisioned",
+                "description": "Physical port ${port_id} state changed to deprovisioned",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.physical_port.state.deprovisioning",
+                "description": "Physical port ${port_id} state changed to deprovisioning",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.physical_port.state.failed",
+                "description": "Physical port ${port_id} state changed to failed",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.physical_port.state.pending_cross_connect",
+                "description": "Physical port ${port_id} state changed to pending_cross_connect",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.physical_port.state.provisioned",
+                "description": "Physical port ${port_id} state changed to provisioned",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.fabric.physical_port.state.provisioning",
+                "description": "Physical port ${port_id} state changed to provisioning",
+                "releaseStatus": "released"
+            },
+            {
                 "name": "equinix.fabric.port.state.deprovisioned",
                 "description": "Virtual port named ${port_name} state changed to deprovisioned",
                 "releaseStatus": "released"
@@ -641,36 +671,6 @@
                 "name": "equinix.fabric.connection_bgpipv6_session.status.unknown",
                 "description": "Neighbor ${IP} address session state changed to Unknown",
                 "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.physical_port.state.deprovisioned",
-                "description": "Physical port ${port_id} state changed to deprovisioned",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.physical_port.state.deprovisioning",
-                "description": "Physical port ${port_id} state changed to deprovisioning",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.physical_port.state.failed",
-                "description": "Physical port ${port_id} state changed to failed",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.physical_port.state.pending_cross_connect",
-                "description": "Physical port ${port_id} state changed to pending_cross_connect",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.physical_port.state.provisioned",
-                "description": "Physical port ${port_id} state changed to provisioned",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.physical_port.state.provisioning",
-                "description": "Physical port ${port_id} state changed to provisioning",
-                "releaseStatus": "released"
             },
             {
                 "name": "equinix.fabric.route_aggregation.attribute.changed",

--- a/README.md
+++ b/README.md
@@ -475,37 +475,37 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.physical_port.state.deprovisioned</td>
 		<td>Physical port ${port_id} state changed to deprovisioned</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.physical_port.state.deprovisioning</td>
 		<td>Physical port ${port_id} state changed to deprovisioning</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.physical_port.state.failed</td>
 		<td>Physical port ${port_id} state changed to failed</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.physical_port.state.pending_cross_connect</td>
 		<td>Physical port ${port_id} state changed to pending_cross_connect</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.physical_port.state.provisioned</td>
 		<td>Physical port ${port_id} state changed to provisioned</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.physical_port.state.provisioning</td>
 		<td>Physical port ${port_id} state changed to provisioning</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
 	</tr>
 	<tr>

--- a/jsonschema/catalog.json
+++ b/jsonschema/catalog.json
@@ -414,37 +414,37 @@
                     "name": "equinix.fabric.physical_port.state.deprovisioned",
                     "description": "Physical port ${port_id} state changed to deprovisioned",
                     "sloCategoryCode": "BLUE_EVENT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.physical_port.state.deprovisioning",
                     "description": "Physical port ${port_id} state changed to deprovisioning",
                     "sloCategoryCode": "BLUE_EVENT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.physical_port.state.failed",
                     "description": "Physical port ${port_id} state changed to failed",
                     "sloCategoryCode": "BLUE_EVENT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.physical_port.state.pending_cross_connect",
                     "description": "Physical port ${port_id} state changed to pending_cross_connect",
                     "sloCategoryCode": "BLUE_EVENT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.physical_port.state.provisioned",
                     "description": "Physical port ${port_id} state changed to provisioned",
                     "sloCategoryCode": "BLUE_EVENT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.physical_port.state.provisioning",
                     "description": "Physical port ${port_id} state changed to provisioning",
                     "sloCategoryCode": "BLUE_EVENT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.fabric.port.state.deprovisioned",

--- a/jsonschema/equinix/fabric/v1/ChangeEvent.json
+++ b/jsonschema/equinix/fabric/v1/ChangeEvent.json
@@ -437,37 +437,37 @@
             "name": "equinix.fabric.physical_port.state.provisioning",
             "description": "Physical port ${port_id} state changed to provisioning",
             "sloCategoryCode": "BLUE_EVENT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.physical_port.state.pending_cross_connect",
             "description": "Physical port ${port_id} state changed to pending_cross_connect",
             "sloCategoryCode": "BLUE_EVENT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.physical_port.state.provisioned",
             "description": "Physical port ${port_id} state changed to provisioned",
             "sloCategoryCode": "BLUE_EVENT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.physical_port.state.deprovisioning",
             "description": "Physical port ${port_id} state changed to deprovisioning",
             "sloCategoryCode": "BLUE_EVENT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.physical_port.state.deprovisioned",
             "description": "Physical port ${port_id} state changed to deprovisioned",
             "sloCategoryCode": "BLUE_EVENT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.physical_port.state.failed",
             "description": "Physical port ${port_id} state changed to failed",
             "sloCategoryCode": "BLUE_EVENT_SLO",
-            "releaseStatus": "preview"
+            "releaseStatus": "released"
         },
         {
             "name": "equinix.fabric.router.state.provisioning",


### PR DESCRIPTION
## Checklist
- [X] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I certify that my `preview` and `released` lists for Events/Metrics/Alerts are correct
- [X] I certify that all Events/Metrics/Alerts in `released` are properly tested and ready for production
