### PR TITLE
Adding cloud event types to support ESH notifications for network rep…

### DIFF
--- a/DataLoader.json
+++ b/DataLoader.json
@@ -738,6 +738,31 @@
                 "releaseStatus": "released"
             },
             {
+                "name": "equinix.network.repair.state.cancelled",
+                "description": "Network repair state changed to cancelled",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.network.repair.state.confirmed",
+                "description": "Network repair state changed to confirmed",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.network.repair.state.in_progress",
+                "description": "Network repair state changed to in_progress",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.network.repair.state.rescheduled",
+                "description": "Network repair state changed to rescheduled",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.network.repair.state.resolved",
+                "description": "Network repair state changed to resolved",
+                "releaseStatus": "released"
+            },
+            {
                 "name": "equinix.fabric.route_aggregation.attribute.changed",
                 "description": "Route Aggregation named ${route_aggregation_name} attribute changed",
                 "releaseStatus": "preview"
@@ -858,33 +883,8 @@
                 "releaseStatus": "preview"
             },
             {
-                "name": "equinix.network.repair.state.cancelled",
-                "description": "Network repair state changed to cancelled",
-                "releaseStatus": "preview"
-            },
-            {
                 "name": "equinix.network.repair.state.completed",
                 "description": "Network repair state changed to completed",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.network.repair.state.confirmed",
-                "description": "Network repair state changed to confirmed",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.network.repair.state.in_progress",
-                "description": "Network repair state changed to in_progress",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.network.repair.state.rescheduled",
-                "description": "Network repair state changed to rescheduled",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.network.repair.state.resolved",
-                "description": "Network repair state changed to resolved",
                 "releaseStatus": "preview"
             }
         ],

--- a/README.md
+++ b/README.md
@@ -1118,7 +1118,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.network.repair.state.cancelled</td>
 		<td>Network repair state changed to cancelled</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1130,25 +1130,25 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.network.repair.state.confirmed</td>
 		<td>Network repair state changed to confirmed</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.network.repair.state.in_progress</td>
 		<td>Network repair state changed to in_progress</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.network.repair.state.rescheduled</td>
 		<td>Network repair state changed to rescheduled</td>
-		<td>preview</td>
+		<td>released</td>
 	<td>-</td>
 	</tr>
 	<tr>
 		<td>equinix.network.repair.state.resolved</td>
 		<td>Network repair state changed to resolved</td>
-		<td>preview</td>
+		<td>released</td>
 	<td>-</td>
 	</tr>
 </table>

--- a/jsonschema/catalog.json
+++ b/jsonschema/catalog.json
@@ -1047,7 +1047,7 @@
                     "name": "equinix.network.repair.state.cancelled",
                     "description": "Network repair state changed to cancelled",
                     "sloCategoryCode": "BLUE_EVENT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.network.repair.state.completed",
@@ -1059,23 +1059,23 @@
                     "name": "equinix.network.repair.state.confirmed",
                     "description": "Network repair state changed to confirmed",
                     "sloCategoryCode": "BLUE_EVENT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.network.repair.state.in_progress",
                     "description": "Network repair state changed to in_progress",
                     "sloCategoryCode": "BLUE_EVENT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.network.repair.state.rescheduled",
                     "description": "Network repair state changed to rescheduled",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.network.repair.state.resolved",
                     "description": "Network repair state changed to resolved",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 }
             ],
             "metricNames": [],

--- a/jsonschema/equinix/fabric/v1/Incident.json
+++ b/jsonschema/equinix/fabric/v1/Incident.json
@@ -161,19 +161,19 @@
       "name": "equinix.network.repair.state.confirmed",
       "description": "Network repair state changed to confirmed",
       "sloCategoryCode": "BLUE_EVENT_SLO",
-      "releaseStatus": "preview"
+      "releaseStatus": "released"
     },
     {
       "name": "equinix.network.repair.state.in_progress",
       "description": "Network repair state changed to in_progress",
       "sloCategoryCode": "BLUE_EVENT_SLO",
-      "releaseStatus": "preview"
+      "releaseStatus": "released"
     },
     {
       "name": "equinix.network.repair.state.cancelled",
       "description": "Network repair state changed to cancelled",
       "sloCategoryCode": "BLUE_EVENT_SLO",
-      "releaseStatus": "preview"
+      "releaseStatus": "released"
     },
     {
       "name": "equinix.network.repair.state.completed",
@@ -184,12 +184,12 @@
     {
       "name": "equinix.network.repair.state.rescheduled",
       "description": "Network repair state changed to rescheduled",
-      "releaseStatus": "preview"
+      "releaseStatus": "released"
     },
     {
       "name": "equinix.network.repair.state.resolved",
       "description": "Network repair state changed to resolved",
-      "releaseStatus": "preview"
+      "releaseStatus": "released"
     }
   ],
   "metricNames": [],


### PR DESCRIPTION
…airs

## Checklist
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I certify that my `preview` and `released` lists for Events/Metrics/Alerts are correct
- [x] I certify that all Events/Metrics/Alerts in `released` are properly tested and ready for production
