### PR TITLE
update jitter_avg status and remove byte count metrics

### DIFF
--- a/DataLoader.json
+++ b/DataLoader.json
@@ -945,18 +945,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.am_{metroCode}.jitter_avg",
-                "description": "Amsterdam to ${metro} intermetro average jitter in microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.am_{metroCode}.latency",
                 "description": "Amsterdam to ${metro} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.at_{metroCode}.jitter_avg",
-                "description": "Atlanta to ${metro} intermetro average jitter in microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -965,18 +955,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.ba_{metroCode}.jitter_avg",
-                "description": "Barcelona to ${metro} intermetro average jitter in microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.ba_{metroCode}.latency",
                 "description": "Barcelona to ${metro} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.bg_{metroCode}.jitter_avg",
-                "description": "Bogota to ${metro} intermetro average jitter in microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -985,18 +965,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.bl_{metroCode}.jitter_avg",
-                "description": "Brussels to ${metro} intermetro average jitter in microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.bl_{metroCode}.latency",
                 "description": "Brussels to ${metro} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.bo_{metroCode}.jitter_avg",
-                "description": "Boston to ${metro} intermetro average jitter in microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1005,18 +975,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.bx_{metroCode}.jitter_avg",
-                "description": "Bordeaux to ${metro} intermetro average jitter in microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.bx_{metroCode}.latency",
                 "description": "Bordeaux to ${metro} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.ca_{metroCode}.jitter_avg",
-                "description": "Canberra to ${metro} intermetro average jitter in microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1025,18 +985,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.ch_{metroCode}.jitter_avg",
-                "description": "Chicago to ${metro} intermetro average jitter in microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.ch_{metroCode}.latency",
                 "description": "Chicago to ${metro} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.cl_{metroCode}.jitter_avg",
-                "description": "Calgary to ${metro} intermetro average jitter in microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1045,18 +995,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.cu_{metroCode}.jitter_avg",
-                "description": "Culpeper to ${metro} intermetro average jitter in microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.cu_{metroCode}.latency",
                 "description": "Culpeper to ${metro} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.da_{metroCode}.jitter_avg",
-                "description": "Dallas to ${metro} intermetro average jitter in microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1065,18 +1005,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.db_{metroCode}.jitter_avg",
-                "description": "Dublin to ${metro} intermetro average jitter in microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.db_{metroCode}.latency",
                 "description": "Dublin to ${metro} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.dc_{metroCode}.jitter_avg",
-                "description": "Ashburn to ${metro} intermetro average jitter in microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1085,18 +1015,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.de_{metroCode}.jitter_avg",
-                "description": "Denver to ${metro} intermetro average jitter in microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.de_{metroCode}.latency",
                 "description": "Denver to ${metro} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.dx_{metroCode}.jitter_avg",
-                "description": "Dubai to ${metro} intermetro average jitter in microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1105,18 +1025,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.fr_{metroCode}.jitter_avg",
-                "description": "Frankfurt to ${metro} intermetro average jitter in microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.fr_{metroCode}.latency",
                 "description": "Frankfurt to ${metro} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.gv_{metroCode}.jitter_avg",
-                "description": "Geneva to ${metro} intermetro average jitter in microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1125,18 +1035,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.he_{metroCode}.jitter_avg",
-                "description": "Helsinki to ${metro} intermetro average jitter in microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.he_{metroCode}.latency",
                 "description": "Helsinki to ${metro} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.hh_{metroCode}.jitter_avg",
-                "description": "Hamburg to ${metro} intermetro average jitter in microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1145,18 +1045,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.hk_{metroCode}.jitter_avg",
-                "description": "Hong Kong to ${metro} intermetro average jitter in microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.hk_{metroCode}.latency",
                 "description": "Hong Kong to ${metro} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.ho_{metroCode}.jitter_avg",
-                "description": "Houston to ${metro} intermetro average jitter in microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1165,18 +1055,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.il_{metroCode}.jitter_avg",
-                "description": "Istanbul to ${metro} intermetro average jitter in microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.il_{metroCode}.latency",
                 "description": "Istanbul to ${metro} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.jh_{metroCode}.jitter_avg",
-                "description": "Johor to ${metro} intermetro average jitter in microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1185,18 +1065,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.jk_{metroCode}.jitter_avg",
-                "description": "Jakarta to ${metro} intermetro average jitter in microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.jk_{metroCode}.latency",
                 "description": "Jakarta to ${metro} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.jn_{metroCode}.jitter_avg",
-                "description": "Johannesburg to ${metro} intermetro average jitter in microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1205,18 +1075,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.ka_{metroCode}.jitter_avg",
-                "description": "Kamloops to ${metro} intermetro average jitter in microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.ka_{metroCode}.latency",
                 "description": "Kamloops to ${metro} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.kl_{metroCode}.jitter_avg",
-                "description": "Kuala Lumpur to ${metro} intermetro average jitter in microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1225,18 +1085,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.la_{metroCode}.jitter_avg",
-                "description": "Los Angeles to ${metro} intermetro average jitter in microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.la_{metroCode}.latency",
                 "description": "Los Angeles to ${metro} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.ld_{metroCode}.jitter_avg",
-                "description": "London to ${metro} intermetro average jitter in microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1245,18 +1095,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.lm_{metroCode}.jitter_avg",
-                "description": "Lima to ${metro} intermetro average jitter in microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.lm_{metroCode}.latency",
                 "description": "Lima to ${metro} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.ls_{metroCode}.jitter_avg",
-                "description": "Lisbon to ${metro} intermetro average jitter in microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1265,18 +1105,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.ma_{metroCode}.jitter_avg",
-                "description": "Manchester to ${metro} intermetro average jitter in microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.ma_{metroCode}.latency",
                 "description": "Manchester to ${metro} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.mb_{metroCode}.jitter_avg",
-                "description": "Mumbai to ${metro} intermetro average jitter in microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1285,18 +1115,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.md_{metroCode}.jitter_avg",
-                "description": "Madrid to ${metro} intermetro average jitter in microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.md_{metroCode}.latency",
                 "description": "Madrid to ${metro} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.me_{metroCode}.jitter_avg",
-                "description": "Melbourne to ${metro} intermetro average jitter in microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1305,18 +1125,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.mi_{metroCode}.jitter_avg",
-                "description": "Miami to ${metro} intermetro average jitter in microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.mi_{metroCode}.latency",
                 "description": "Miami to ${metro} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.ml_{metroCode}.jitter_avg",
-                "description": "Milan to ${metro} intermetro average jitter in microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1325,18 +1135,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.mo_{metroCode}.jitter_avg",
-                "description": "Monterrey to ${metro} intermetro average jitter in microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.mo_{metroCode}.latency",
                 "description": "Monterrey to ${metro} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.mt_{metroCode}.jitter_avg",
-                "description": "Montreal to ${metro} intermetro average jitter in microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1345,18 +1145,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.mu_{metroCode}.jitter_avg",
-                "description": "Munich to ${metro} intermetro average jitter in microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.mu_{metroCode}.latency",
                 "description": "Munich to ${metro} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.mx_{metroCode}.jitter_avg",
-                "description": "Mexico City to ${metro} intermetro average jitter in microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1365,18 +1155,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.ny_{metroCode}.jitter_avg",
-                "description": "New York to ${metro} intermetro average jitter in microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.ny_{metroCode}.latency",
                 "description": "New York to ${metro} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.os_{metroCode}.jitter_avg",
-                "description": "Osaka to ${metro} intermetro average jitter in microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1385,18 +1165,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.ot_{metroCode}.jitter_avg",
-                "description": "Ottawa to ${metro} intermetro average jitter in microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.ot_{metroCode}.latency",
                 "description": "Ottawa to ${metro} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.pa_{metroCode}.jitter_avg",
-                "description": "Paris to ${metro} intermetro average jitter in microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1405,18 +1175,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.pe_{metroCode}.jitter_avg",
-                "description": "Perth to ${metro} intermetro average jitter in microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.pe_{metroCode}.latency",
                 "description": "Perth to ${metro} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.ph_{metroCode}.jitter_avg",
-                "description": "Philadelphia to ${metro} intermetro average jitter in microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1425,18 +1185,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.rj_{metroCode}.jitter_avg",
-                "description": "Rio de Janeiro to ${metro} intermetro average jitter in microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.rj_{metroCode}.latency",
                 "description": "Rio de Janeiro to ${metro} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.se_{metroCode}.jitter_avg",
-                "description": "Seattle to ${metro} intermetro average jitter in microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1445,18 +1195,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.sg_{metroCode}.jitter_avg",
-                "description": "Singapore to ${metro} intermetro average jitter in microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.sg_{metroCode}.latency",
                 "description": "Singapore to ${metro} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.sk_{metroCode}.jitter_avg",
-                "description": "Stockholm to ${metro} intermetro average jitter in microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1465,18 +1205,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.sl_{metroCode}.jitter_avg",
-                "description": "Seoul to ${metro} intermetro average jitter in microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.sl_{metroCode}.latency",
                 "description": "Seoul to ${metro} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.so_{metroCode}.jitter_avg",
-                "description": "Sofia to ${metro} intermetro average jitter in microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1485,18 +1215,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.sp_{metroCode}.jitter_avg",
-                "description": "Sao Paulo to ${metro} intermetro average jitter in microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.sp_{metroCode}.latency",
                 "description": "Sao Paulo to ${metro} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.st_{metroCode}.jitter_avg",
-                "description": "Santiago to ${metro} intermetro average jitter in microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1505,18 +1225,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.sv_{metroCode}.jitter_avg",
-                "description": "Silicon Valley to ${metro} intermetro average jitter in microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.sv_{metroCode}.latency",
                 "description": "Silicon Valley to ${metro} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.sy_{metroCode}.jitter_avg",
-                "description": "Sydney to ${metro} intermetro average jitter in microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1525,18 +1235,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.tr_{metroCode}.jitter_avg",
-                "description": "Toronto to ${metro} intermetro average jitter in microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.tr_{metroCode}.latency",
                 "description": "Toronto to ${metro} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.ty_{metroCode}.jitter_avg",
-                "description": "Tokyo to ${metro} intermetro average jitter in microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1545,18 +1245,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.va_{metroCode}.jitter_avg",
-                "description": "Vancouver to ${metro} intermetro average jitter in microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.va_{metroCode}.latency",
                 "description": "Vancouver to ${metro} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.wa_{metroCode}.jitter_avg",
-                "description": "Warsaw to ${metro} intermetro average jitter in microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1565,18 +1255,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.wi_{metroCode}.jitter_avg",
-                "description": "Winnipeg to ${metro} intermetro average jitter in microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.wi_{metroCode}.latency",
                 "description": "Winnipeg to ${metro} intermetro latency, average in milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.zh_{metroCode}.jitter_avg",
-                "description": "Zurich to ${metro} intermetro average jitter in microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1632,6 +1312,326 @@
             {
                 "name": "equinix.fabric.connection.byte_tx.count",
                 "description": "Connection outbound dropped byte count",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.am_{metroCode}.jitter_avg",
+                "description": "Amsterdam to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.at_{metroCode}.jitter_avg",
+                "description": "Atlanta to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.ba_{metroCode}.jitter_avg",
+                "description": "Barcelona to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.bg_{metroCode}.jitter_avg",
+                "description": "Bogota to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.bl_{metroCode}.jitter_avg",
+                "description": "Brussels to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.bo_{metroCode}.jitter_avg",
+                "description": "Boston to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.bx_{metroCode}.jitter_avg",
+                "description": "Bordeaux to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.ca_{metroCode}.jitter_avg",
+                "description": "Canberra to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.ch_{metroCode}.jitter_avg",
+                "description": "Chicago to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.cl_{metroCode}.jitter_avg",
+                "description": "Calgary to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.cu_{metroCode}.jitter_avg",
+                "description": "Culpeper to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.da_{metroCode}.jitter_avg",
+                "description": "Dallas to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.db_{metroCode}.jitter_avg",
+                "description": "Dublin to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.dc_{metroCode}.jitter_avg",
+                "description": "Ashburn to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.de_{metroCode}.jitter_avg",
+                "description": "Denver to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.dx_{metroCode}.jitter_avg",
+                "description": "Dubai to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.fr_{metroCode}.jitter_avg",
+                "description": "Frankfurt to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.gv_{metroCode}.jitter_avg",
+                "description": "Geneva to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.he_{metroCode}.jitter_avg",
+                "description": "Helsinki to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.hh_{metroCode}.jitter_avg",
+                "description": "Hamburg to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.hk_{metroCode}.jitter_avg",
+                "description": "Hong Kong to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.ho_{metroCode}.jitter_avg",
+                "description": "Houston to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.il_{metroCode}.jitter_avg",
+                "description": "Istanbul to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.jh_{metroCode}.jitter_avg",
+                "description": "Johor to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.jk_{metroCode}.jitter_avg",
+                "description": "Jakarta to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.jn_{metroCode}.jitter_avg",
+                "description": "Johannesburg to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.ka_{metroCode}.jitter_avg",
+                "description": "Kamloops to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.kl_{metroCode}.jitter_avg",
+                "description": "Kuala Lumpur to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.la_{metroCode}.jitter_avg",
+                "description": "Los Angeles to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.ld_{metroCode}.jitter_avg",
+                "description": "London to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.lm_{metroCode}.jitter_avg",
+                "description": "Lima to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.ls_{metroCode}.jitter_avg",
+                "description": "Lisbon to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.ma_{metroCode}.jitter_avg",
+                "description": "Manchester to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.mb_{metroCode}.jitter_avg",
+                "description": "Mumbai to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.md_{metroCode}.jitter_avg",
+                "description": "Madrid to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.me_{metroCode}.jitter_avg",
+                "description": "Melbourne to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.mi_{metroCode}.jitter_avg",
+                "description": "Miami to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.ml_{metroCode}.jitter_avg",
+                "description": "Milan to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.mo_{metroCode}.jitter_avg",
+                "description": "Monterrey to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.mt_{metroCode}.jitter_avg",
+                "description": "Montreal to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.mu_{metroCode}.jitter_avg",
+                "description": "Munich to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.mx_{metroCode}.jitter_avg",
+                "description": "Mexico City to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.ny_{metroCode}.jitter_avg",
+                "description": "New York to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.os_{metroCode}.jitter_avg",
+                "description": "Osaka to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.ot_{metroCode}.jitter_avg",
+                "description": "Ottawa to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.pa_{metroCode}.jitter_avg",
+                "description": "Paris to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.pe_{metroCode}.jitter_avg",
+                "description": "Perth to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.ph_{metroCode}.jitter_avg",
+                "description": "Philadelphia to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.rj_{metroCode}.jitter_avg",
+                "description": "Rio de Janeiro to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.se_{metroCode}.jitter_avg",
+                "description": "Seattle to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.sg_{metroCode}.jitter_avg",
+                "description": "Singapore to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.sk_{metroCode}.jitter_avg",
+                "description": "Stockholm to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.sl_{metroCode}.jitter_avg",
+                "description": "Seoul to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.so_{metroCode}.jitter_avg",
+                "description": "Sofia to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.sp_{metroCode}.jitter_avg",
+                "description": "Sao Paulo to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.st_{metroCode}.jitter_avg",
+                "description": "Santiago to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.sv_{metroCode}.jitter_avg",
+                "description": "Silicon Valley to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.sy_{metroCode}.jitter_avg",
+                "description": "Sydney to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.tr_{metroCode}.jitter_avg",
+                "description": "Toronto to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.ty_{metroCode}.jitter_avg",
+                "description": "Tokyo to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.va_{metroCode}.jitter_avg",
+                "description": "Vancouver to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.wa_{metroCode}.jitter_avg",
+                "description": "Warsaw to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.wi_{metroCode}.jitter_avg",
+                "description": "Winnipeg to ${metro} intermetro average jitter in microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.zh_{metroCode}.jitter_avg",
+                "description": "Zurich to ${metro} intermetro average jitter in microseconds",
                 "releaseStatus": "preview"
             },
             {
@@ -1697,18 +1697,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.am_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Amsterdam to ${metro} is ${operator} ${operand} microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.am_{metroCode}.latency",
                 "description": "Metro latency from Amsterdam to ${metro} is ${operator} ${operand} milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.at_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Atlanta to ${metro} is ${operator} ${operand} microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1717,18 +1707,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.ba_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Barcelona to ${metro} is ${operator} ${operand} microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.ba_{metroCode}.latency",
                 "description": "Metro latency from Barcelona to ${metro} is ${operator} ${operand} milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.bg_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Bogota to ${metro} is ${operator} ${operand} microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1737,18 +1717,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.bl_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Brussels to ${metro} is ${operator} ${operand} microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.bl_{metroCode}.latency",
                 "description": "Metro latency from Brussels to ${metro} is ${operator} ${operand} milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.bo_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Boston to ${metro} is ${operator} ${operand} microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1757,18 +1727,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.bx_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Bordeaux to ${metro} is ${operator} ${operand} microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.bx_{metroCode}.latency",
                 "description": "Metro latency from Bordeaux to ${metro} is ${operator} ${operand} milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.ca_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Canberra to ${metro} is ${operator} ${operand} microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1777,18 +1737,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.ch_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Chicago to ${metro} is ${operator} ${operand} microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.ch_{metroCode}.latency",
                 "description": "Metro latency from Chicago to ${metro} is ${operator} ${operand} milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.cl_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Calgary to ${metro} is ${operator} ${operand} microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1797,18 +1747,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.cu_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Culpeper to ${metro} is ${operator} ${operand} microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.cu_{metroCode}.latency",
                 "description": "Metro latency from Culpeper to ${metro} is ${operator} ${operand} milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.da_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Dallas to ${metro} is ${operator} ${operand} microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1817,18 +1757,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.db_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Dublin to ${metro} is ${operator} ${operand} microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.db_{metroCode}.latency",
                 "description": "Metro latency from Dublin to ${metro} is ${operator} ${operand} milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.dc_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Ashburn to ${metro} is ${operator} ${operand} microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1837,18 +1767,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.de_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Denver to ${metro} is ${operator} ${operand} microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.de_{metroCode}.latency",
                 "description": "Metro latency from Denver to ${metro} is ${operator} ${operand} milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.dx_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Dubai to ${metro} is ${operator} ${operand} microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1857,18 +1777,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.fr_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Frankfurt to ${metro} is ${operator} ${operand} microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.fr_{metroCode}.latency",
                 "description": "Metro latency from Frankfurt to ${metro} is ${operator} ${operand} milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.gv_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Geneva to ${metro} is ${operator} ${operand} microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1877,18 +1787,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.he_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Helsinki to ${metro} is ${operator} ${operand} microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.he_{metroCode}.latency",
                 "description": "Metro latency from Helsinki to ${metro} is ${operator} ${operand} milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.hh_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Hamburg to ${metro} is ${operator} ${operand} microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1897,18 +1797,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.hk_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Hong Kong to ${metro} is ${operator} ${operand} microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.hk_{metroCode}.latency",
                 "description": "Metro latency from Hong Kong to ${metro} is ${operator} ${operand} milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.ho_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Houston to ${metro} is ${operator} ${operand} microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1917,18 +1807,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.il_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Istanbul to ${metro} is ${operator} ${operand} microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.il_{metroCode}.latency",
                 "description": "Metro latency from Istanbul to ${metro} is ${operator} ${operand} milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.jh_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Johor to ${metro} is ${operator} ${operand} microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1937,18 +1817,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.jk_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Jakarta to ${metro} is ${operator} ${operand} microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.jk_{metroCode}.latency",
                 "description": "Metro latency from Jakarta to ${metro} is ${operator} ${operand} milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.jn_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Johannesburg to ${metro} is ${operator} ${operand} microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1957,18 +1827,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.ka_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Kamloops to ${metro} is ${operator} ${operand} microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.ka_{metroCode}.latency",
                 "description": "Metro latency from Kamloops to ${metro} is ${operator} ${operand} milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.kl_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Kuala Lumpur to ${metro} is ${operator} ${operand} microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1977,18 +1837,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.la_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Los Angeles to ${metro} is ${operator} ${operand} microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.la_{metroCode}.latency",
                 "description": "Metro latency from Los Angeles to ${metro} is ${operator} ${operand} milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.ld_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from London to ${metro} is ${operator} ${operand} microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -1997,18 +1847,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.lm_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Lima to ${metro} is ${operator} ${operand} microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.lm_{metroCode}.latency",
                 "description": "Metro latency from Lima to ${metro} is ${operator} ${operand} milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.ls_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Lisbon to ${metro} is ${operator} ${operand} microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -2017,18 +1857,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.ma_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Manchester to ${metro} is ${operator} ${operand} microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.ma_{metroCode}.latency",
                 "description": "Metro latency from Manchester to ${metro} is ${operator} ${operand} milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.mb_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Mumbai to ${metro} is ${operator} ${operand} microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -2037,18 +1867,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.md_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Madrid to ${metro} is ${operator} ${operand} microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.md_{metroCode}.latency",
                 "description": "Metro latency from Madrid to ${metro} is ${operator} ${operand} milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.me_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Melbourne to ${metro} is ${operator} ${operand} microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -2057,18 +1877,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.mi_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Miami to ${metro} is ${operator} ${operand} microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.mi_{metroCode}.latency",
                 "description": "Metro latency from Miami to ${metro} is ${operator} ${operand} milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.ml_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Milan to ${metro} is ${operator} ${operand} microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -2077,18 +1887,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.mo_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Monterrey to ${metro} is ${operator} ${operand} microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.mo_{metroCode}.latency",
                 "description": "Metro latency from Monterrey to ${metro} is ${operator} ${operand} milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.mt_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Montreal to ${metro} is ${operator} ${operand} microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -2097,18 +1897,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.mu_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Munich to ${metro} is ${operator} ${operand} microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.mu_{metroCode}.latency",
                 "description": "Metro latency from Munich to ${metro} is ${operator} ${operand} milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.mx_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Mexico City to ${metro} is ${operator} ${operand} microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -2117,18 +1907,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.ny_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from New York to ${metro} is ${operator} ${operand} microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.ny_{metroCode}.latency",
                 "description": "Metro latency from New York to ${metro} is ${operator} ${operand} milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.os_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Osaka to ${metro} is ${operator} ${operand} microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -2137,18 +1917,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.ot_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Ottawa to ${metro} is ${operator} ${operand} microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.ot_{metroCode}.latency",
                 "description": "Metro latency from Ottawa to ${metro} is ${operator} ${operand} milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.pa_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Paris to ${metro} is ${operator} ${operand} microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -2157,18 +1927,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.pe_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Perth to ${metro} is ${operator} ${operand} microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.pe_{metroCode}.latency",
                 "description": "Metro latency from Perth to ${metro} is ${operator} ${operand} milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.ph_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Philadelphia to ${metro} is ${operator} ${operand} microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -2177,18 +1937,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.rj_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Rio de Janeiro to ${metro} is ${operator} ${operand} microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.rj_{metroCode}.latency",
                 "description": "Metro latency from Rio de Janeiro to ${metro} is ${operator} ${operand} milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.se_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Seattle to ${metro} is ${operator} ${operand} microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -2197,18 +1947,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.sg_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Singapore to ${metro} is ${operator} ${operand} microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.sg_{metroCode}.latency",
                 "description": "Metro latency from Singapore to ${metro} is ${operator} ${operand} milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.sk_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Stockholm to ${metro} is ${operator} ${operand} microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -2217,18 +1957,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.sl_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Seoul to ${metro} is ${operator} ${operand} microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.sl_{metroCode}.latency",
                 "description": "Metro latency from Seoul to ${metro} is ${operator} ${operand} milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.so_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Sofia to ${metro} is ${operator} ${operand} microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -2237,18 +1967,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.sp_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Sao Paulo to ${metro} is ${operator} ${operand} microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.sp_{metroCode}.latency",
                 "description": "Metro latency from Sao Paulo to ${metro} is ${operator} ${operand} milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.st_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Santiago to ${metro} is ${operator} ${operand} microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -2257,18 +1977,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.sv_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Silicon Valley to ${metro} is ${operator} ${operand} microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.sv_{metroCode}.latency",
                 "description": "Metro latency from Silicon Valley to ${metro} is ${operator} ${operand} milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.sy_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Sydney to ${metro} is ${operator} ${operand} microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -2277,18 +1987,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.tr_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Toronto to ${metro} is ${operator} ${operand} microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.tr_{metroCode}.latency",
                 "description": "Metro latency from Toronto to ${metro} is ${operator} ${operand} milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.ty_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Tokyo to ${metro} is ${operator} ${operand} microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -2297,18 +1997,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.va_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Vancouver to ${metro} is ${operator} ${operand} microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.va_{metroCode}.latency",
                 "description": "Metro latency from Vancouver to ${metro} is ${operator} ${operand} milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.wa_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Warsaw to ${metro} is ${operator} ${operand} microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -2317,18 +2007,8 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.metro.wi_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Winnipeg to ${metro} is ${operator} ${operand} microseconds",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.metro.wi_{metroCode}.latency",
                 "description": "Metro latency from Winnipeg to ${metro} is ${operator} ${operand} milliseconds",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.metro.zh_{metroCode}.jitter_avg",
-                "description": "Average metro jitter from Zurich to ${metro} is ${operator} ${operand} microseconds",
                 "releaseStatus": "released"
             },
             {
@@ -2394,6 +2074,326 @@
             {
                 "name": "equinix.fabric.connection.byte_tx.count",
                 "description": "Connection outbound byte count is ${operator} ${operand} MB",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.am_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Amsterdam to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.at_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Atlanta to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.ba_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Barcelona to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.bg_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Bogota to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.bl_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Brussels to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.bo_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Boston to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.bx_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Bordeaux to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.ca_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Canberra to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.ch_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Chicago to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.cl_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Calgary to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.cu_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Culpeper to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.da_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Dallas to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.db_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Dublin to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.dc_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Ashburn to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.de_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Denver to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.dx_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Dubai to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.fr_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Frankfurt to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.gv_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Geneva to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.he_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Helsinki to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.hh_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Hamburg to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.hk_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Hong Kong to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.ho_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Houston to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.il_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Istanbul to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.jh_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Johor to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.jk_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Jakarta to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.jn_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Johannesburg to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.ka_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Kamloops to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.kl_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Kuala Lumpur to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.la_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Los Angeles to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.ld_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from London to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.lm_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Lima to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.ls_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Lisbon to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.ma_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Manchester to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.mb_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Mumbai to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.md_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Madrid to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.me_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Melbourne to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.mi_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Miami to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.ml_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Milan to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.mo_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Monterrey to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.mt_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Montreal to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.mu_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Munich to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.mx_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Mexico City to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.ny_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from New York to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.os_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Osaka to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.ot_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Ottawa to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.pa_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Paris to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.pe_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Perth to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.ph_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Philadelphia to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.rj_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Rio de Janeiro to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.se_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Seattle to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.sg_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Singapore to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.sk_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Stockholm to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.sl_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Seoul to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.so_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Sofia to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.sp_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Sao Paulo to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.st_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Santiago to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.sv_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Silicon Valley to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.sy_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Sydney to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.tr_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Toronto to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.ty_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Tokyo to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.va_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Vancouver to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.wa_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Warsaw to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.wi_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Winnipeg to ${metro} is ${operator} ${operand} microseconds",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.metro.zh_{metroCode}.jitter_avg",
+                "description": "Average metro jitter from Zurich to ${metro} is ${operator} ${operand} microseconds",
                 "releaseStatus": "preview"
             },
             {

--- a/DataLoader.json
+++ b/DataLoader.json
@@ -1305,16 +1305,6 @@
                 "releaseStatus": "preview"
             },
             {
-                "name": "equinix.fabric.connection.byte_rx.count",
-                "description": "Connection inbound dropped byte count",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.connection.byte_tx.count",
-                "description": "Connection outbound dropped byte count",
-                "releaseStatus": "preview"
-            },
-            {
                 "name": "equinix.fabric.metro.am_{metroCode}.jitter_avg",
                 "description": "Amsterdam to ${metro} intermetro average jitter in microseconds",
                 "releaseStatus": "preview"
@@ -1642,16 +1632,6 @@
             {
                 "name": "equinix.fabric.port.bandwidth_tx.utilization",
                 "description": "Port outbound bandwidth utilization in %",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.port.byte_rx.count",
-                "description": "Port inbound dropped byte count",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.port.byte_tx.count",
-                "description": "Port outbound dropped byte count",
                 "releaseStatus": "preview"
             }
         ],
@@ -2067,16 +2047,6 @@
                 "releaseStatus": "preview"
             },
             {
-                "name": "equinix.fabric.connection.byte_rx.count",
-                "description": "Connection inbound byte count is ${operator} ${operand} MB",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.connection.byte_tx.count",
-                "description": "Connection outbound byte count is ${operator} ${operand} MB",
-                "releaseStatus": "preview"
-            },
-            {
                 "name": "equinix.fabric.metro.am_{metroCode}.jitter_avg",
                 "description": "Average metro jitter from Amsterdam to ${metro} is ${operator} ${operand} microseconds",
                 "releaseStatus": "preview"
@@ -2404,16 +2374,6 @@
             {
                 "name": "equinix.fabric.port.bandwidth_tx.utilization",
                 "description": "Port outbound bandwidth utilization is ${operator} ${operand}%",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.port.byte_rx.count",
-                "description": "Port inbound byte count is ${operator} ${operand} MB",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.fabric.port.byte_tx.count",
-                "description": "Port outbound byte count is ${operator} ${operand} MB",
                 "releaseStatus": "preview"
             }
         ]

--- a/README.md
+++ b/README.md
@@ -1277,7 +1277,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.am_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Amsterdam to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1289,7 +1289,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.at_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Atlanta to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1301,7 +1301,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.ba_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Barcelona to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1313,7 +1313,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.bg_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Bogota to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1325,7 +1325,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.bl_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Brussels to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1337,7 +1337,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.bo_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Boston to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1349,7 +1349,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.bx_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Bordeaux to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1361,7 +1361,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.ca_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Canberra to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1373,7 +1373,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.ch_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Chicago to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1385,7 +1385,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.cl_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Calgary to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1397,7 +1397,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.cu_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Culpeper to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1409,7 +1409,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.da_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Dallas to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1421,7 +1421,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.db_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Dublin to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1433,7 +1433,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.dc_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Ashburn to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1445,7 +1445,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.de_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Denver to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1457,7 +1457,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.dx_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Dubai to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1469,7 +1469,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.fr_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Frankfurt to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1481,7 +1481,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.gv_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Geneva to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1493,7 +1493,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.he_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Helsinki to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1505,7 +1505,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.hh_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Hamburg to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1517,7 +1517,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.hk_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Hong Kong to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1529,7 +1529,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.ho_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Houston to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1541,7 +1541,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.il_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Istanbul to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1553,7 +1553,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.jh_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Johor to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1565,7 +1565,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.jk_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Jakarta to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1577,7 +1577,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.jn_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Johannesburg to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1589,7 +1589,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.ka_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Kamloops to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1601,7 +1601,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.kl_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Kuala Lumpur to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1613,7 +1613,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.la_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Los Angeles to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1625,7 +1625,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.ld_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from London to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1637,7 +1637,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.lm_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Lima to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1649,7 +1649,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.ls_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Lisbon to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1661,7 +1661,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.ma_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Manchester to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1673,7 +1673,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.mb_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Mumbai to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1685,7 +1685,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.md_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Madrid to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1697,7 +1697,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.me_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Melbourne to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1709,7 +1709,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.mi_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Miami to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1721,7 +1721,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.ml_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Milan to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1733,7 +1733,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.mo_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Monterrey to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1745,7 +1745,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.mt_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Montreal to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1757,7 +1757,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.mu_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Munich to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1769,7 +1769,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.mx_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Mexico City to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1781,7 +1781,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.ny_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from New York to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1793,7 +1793,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.os_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Osaka to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1805,7 +1805,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.ot_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Ottawa to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1817,7 +1817,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.pa_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Paris to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1829,7 +1829,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.pe_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Perth to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1841,7 +1841,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.ph_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Philadelphia to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1853,7 +1853,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.rj_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Rio de Janeiro to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1865,7 +1865,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.se_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Seattle to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1877,7 +1877,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.sg_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Singapore to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1889,7 +1889,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.sk_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Stockholm to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1901,7 +1901,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.sl_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Seoul to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1913,7 +1913,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.so_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Sofia to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1925,7 +1925,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.sp_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Sao Paulo to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1937,7 +1937,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.st_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Santiago to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1949,7 +1949,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.sv_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Silicon Valley to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1961,7 +1961,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.sy_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Sydney to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1973,7 +1973,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.tr_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Toronto to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1985,7 +1985,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.ty_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Tokyo to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -1997,7 +1997,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.va_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Vancouver to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2009,7 +2009,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.wa_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Warsaw to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2021,7 +2021,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.wi_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Winnipeg to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2033,7 +2033,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.zh_{metroCode}.jitter_avg</td>
 		<td>Average metro jitter from Zurich to ${metro} is ${operator} ${operand} microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2211,7 +2211,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.am_{metroCode}.jitter_avg</td>
 		<td>Amsterdam to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2223,7 +2223,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.at_{metroCode}.jitter_avg</td>
 		<td>Atlanta to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2235,7 +2235,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.ba_{metroCode}.jitter_avg</td>
 		<td>Barcelona to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2247,7 +2247,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.bg_{metroCode}.jitter_avg</td>
 		<td>Bogota to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2259,7 +2259,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.bl_{metroCode}.jitter_avg</td>
 		<td>Brussels to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2271,7 +2271,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.bo_{metroCode}.jitter_avg</td>
 		<td>Boston to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2283,7 +2283,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.bx_{metroCode}.jitter_avg</td>
 		<td>Bordeaux to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2295,7 +2295,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.ca_{metroCode}.jitter_avg</td>
 		<td>Canberra to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2307,7 +2307,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.ch_{metroCode}.jitter_avg</td>
 		<td>Chicago to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2319,7 +2319,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.cl_{metroCode}.jitter_avg</td>
 		<td>Calgary to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2331,7 +2331,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.cu_{metroCode}.jitter_avg</td>
 		<td>Culpeper to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2343,7 +2343,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.da_{metroCode}.jitter_avg</td>
 		<td>Dallas to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2355,7 +2355,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.db_{metroCode}.jitter_avg</td>
 		<td>Dublin to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2367,7 +2367,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.dc_{metroCode}.jitter_avg</td>
 		<td>Ashburn to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2379,7 +2379,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.de_{metroCode}.jitter_avg</td>
 		<td>Denver to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2391,7 +2391,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.dx_{metroCode}.jitter_avg</td>
 		<td>Dubai to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2403,7 +2403,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.fr_{metroCode}.jitter_avg</td>
 		<td>Frankfurt to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2415,7 +2415,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.gv_{metroCode}.jitter_avg</td>
 		<td>Geneva to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2427,7 +2427,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.he_{metroCode}.jitter_avg</td>
 		<td>Helsinki to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2439,7 +2439,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.hh_{metroCode}.jitter_avg</td>
 		<td>Hamburg to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2451,7 +2451,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.hk_{metroCode}.jitter_avg</td>
 		<td>Hong Kong to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2463,7 +2463,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.ho_{metroCode}.jitter_avg</td>
 		<td>Houston to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2475,7 +2475,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.il_{metroCode}.jitter_avg</td>
 		<td>Istanbul to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2487,7 +2487,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.jh_{metroCode}.jitter_avg</td>
 		<td>Johor to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2499,7 +2499,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.jk_{metroCode}.jitter_avg</td>
 		<td>Jakarta to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2511,7 +2511,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.jn_{metroCode}.jitter_avg</td>
 		<td>Johannesburg to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2523,7 +2523,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.ka_{metroCode}.jitter_avg</td>
 		<td>Kamloops to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2535,7 +2535,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.kl_{metroCode}.jitter_avg</td>
 		<td>Kuala Lumpur to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2547,7 +2547,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.la_{metroCode}.jitter_avg</td>
 		<td>Los Angeles to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2559,7 +2559,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.ld_{metroCode}.jitter_avg</td>
 		<td>London to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2571,7 +2571,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.lm_{metroCode}.jitter_avg</td>
 		<td>Lima to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2583,7 +2583,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.ls_{metroCode}.jitter_avg</td>
 		<td>Lisbon to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2595,7 +2595,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.ma_{metroCode}.jitter_avg</td>
 		<td>Manchester to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2607,7 +2607,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.mb_{metroCode}.jitter_avg</td>
 		<td>Mumbai to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2619,7 +2619,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.md_{metroCode}.jitter_avg</td>
 		<td>Madrid to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2631,7 +2631,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.me_{metroCode}.jitter_avg</td>
 		<td>Melbourne to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2643,7 +2643,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.mi_{metroCode}.jitter_avg</td>
 		<td>Miami to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2655,7 +2655,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.ml_{metroCode}.jitter_avg</td>
 		<td>Milan to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2667,7 +2667,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.mo_{metroCode}.jitter_avg</td>
 		<td>Monterrey to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2679,7 +2679,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.mt_{metroCode}.jitter_avg</td>
 		<td>Montreal to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2691,7 +2691,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.mu_{metroCode}.jitter_avg</td>
 		<td>Munich to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2703,7 +2703,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.mx_{metroCode}.jitter_avg</td>
 		<td>Mexico City to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2715,7 +2715,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.ny_{metroCode}.jitter_avg</td>
 		<td>New York to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2727,7 +2727,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.os_{metroCode}.jitter_avg</td>
 		<td>Osaka to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2739,7 +2739,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.ot_{metroCode}.jitter_avg</td>
 		<td>Ottawa to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2751,7 +2751,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.pa_{metroCode}.jitter_avg</td>
 		<td>Paris to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2763,7 +2763,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.pe_{metroCode}.jitter_avg</td>
 		<td>Perth to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2775,7 +2775,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.ph_{metroCode}.jitter_avg</td>
 		<td>Philadelphia to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2787,7 +2787,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.rj_{metroCode}.jitter_avg</td>
 		<td>Rio de Janeiro to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2799,7 +2799,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.se_{metroCode}.jitter_avg</td>
 		<td>Seattle to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2811,7 +2811,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.sg_{metroCode}.jitter_avg</td>
 		<td>Singapore to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2823,7 +2823,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.sk_{metroCode}.jitter_avg</td>
 		<td>Stockholm to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2835,7 +2835,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.sl_{metroCode}.jitter_avg</td>
 		<td>Seoul to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2847,7 +2847,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.so_{metroCode}.jitter_avg</td>
 		<td>Sofia to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2859,7 +2859,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.sp_{metroCode}.jitter_avg</td>
 		<td>Sao Paulo to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2871,7 +2871,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.st_{metroCode}.jitter_avg</td>
 		<td>Santiago to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2883,7 +2883,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.sv_{metroCode}.jitter_avg</td>
 		<td>Silicon Valley to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2895,7 +2895,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.sy_{metroCode}.jitter_avg</td>
 		<td>Sydney to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2907,7 +2907,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.tr_{metroCode}.jitter_avg</td>
 		<td>Toronto to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2919,7 +2919,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.ty_{metroCode}.jitter_avg</td>
 		<td>Tokyo to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2931,7 +2931,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.va_{metroCode}.jitter_avg</td>
 		<td>Vancouver to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2943,7 +2943,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.wa_{metroCode}.jitter_avg</td>
 		<td>Warsaw to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2955,7 +2955,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.wi_{metroCode}.jitter_avg</td>
 		<td>Winnipeg to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>
@@ -2967,7 +2967,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.metro.zh_{metroCode}.jitter_avg</td>
 		<td>Zurich to ${metro} intermetro average jitter in microseconds</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#brown_metric_slo'> <span style='color:brown'>BROWN_METRIC_SLO</span></a></td>
 	</tr>
 	<tr>

--- a/README.md
+++ b/README.md
@@ -1227,18 +1227,6 @@ The following data payloads are the supported events and formats for Equinix Net
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
-		<td>equinix.fabric.connection.byte_rx.count</td>
-		<td>Connection inbound byte count is ${operator} ${operand} MB</td>
-		<td>preview</td>
-	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
-	</tr>
-	<tr>
-		<td>equinix.fabric.connection.byte_tx.count</td>
-		<td>Connection outbound byte count is ${operator} ${operand} MB</td>
-		<td>preview</td>
-	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
-	</tr>
-	<tr>
 		<td>equinix.fabric.connection.installed_routes_ipv4.utilization</td>
 		<td>Utilization of connection active IPv4 routes is ${operator} ${operand}</td>
 		<td>released</td>
@@ -2067,18 +2055,6 @@ The following data payloads are the supported events and formats for Equinix Net
 	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
 	</tr>
 	<tr>
-		<td>equinix.fabric.port.byte_rx.count</td>
-		<td>Port inbound byte count is ${operator} ${operand} MB</td>
-		<td>preview</td>
-	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
-	</tr>
-	<tr>
-		<td>equinix.fabric.port.byte_tx.count</td>
-		<td>Port outbound byte count is ${operator} ${operand} MB</td>
-		<td>preview</td>
-	<td><a href='#blue_alert_slo'> <span style='color:blue'>BLUE_ALERT_SLO</span></a></td>
-	</tr>
-	<tr>
 		<td>equinix.fabric.port.packets_dropped_rx.count</td>
 		<td>Port inbound dropped packets count is ${operator} ${operand}</td>
 		<td>released</td>
@@ -2169,18 +2145,6 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.connection.bandwidth_tx.utilization</td>
 		<td>Connection outbound bandwidth utilization in %</td>
-		<td>preview</td>
-	<td><a href='#purple_metric_slo'> <span style='color:purple'>PURPLE_METRIC_SLO</span></a></td>
-	</tr>
-	<tr>
-		<td>equinix.fabric.connection.byte_rx.count</td>
-		<td>Connection inbound dropped byte count</td>
-		<td>preview</td>
-	<td><a href='#purple_metric_slo'> <span style='color:purple'>PURPLE_METRIC_SLO</span></a></td>
-	</tr>
-	<tr>
-		<td>equinix.fabric.connection.byte_tx.count</td>
-		<td>Connection outbound dropped byte count</td>
 		<td>preview</td>
 	<td><a href='#purple_metric_slo'> <span style='color:purple'>PURPLE_METRIC_SLO</span></a></td>
 	</tr>
@@ -2997,18 +2961,6 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.port.bandwidth_tx.utilization</td>
 		<td>Port outbound bandwidth utilization in %</td>
-		<td>preview</td>
-	<td><a href='#purple_metric_slo'> <span style='color:purple'>PURPLE_METRIC_SLO</span></a></td>
-	</tr>
-	<tr>
-		<td>equinix.fabric.port.byte_rx.count</td>
-		<td>Port inbound dropped byte count</td>
-		<td>preview</td>
-	<td><a href='#purple_metric_slo'> <span style='color:purple'>PURPLE_METRIC_SLO</span></a></td>
-	</tr>
-	<tr>
-		<td>equinix.fabric.port.byte_tx.count</td>
-		<td>Port outbound dropped byte count</td>
 		<td>preview</td>
 	<td><a href='#purple_metric_slo'> <span style='color:purple'>PURPLE_METRIC_SLO</span></a></td>
 	</tr>

--- a/jsonschema/catalog.json
+++ b/jsonschema/catalog.json
@@ -1196,7 +1196,7 @@
                     "name": "equinix.fabric.metro.am_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Amsterdam to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.am_{metroCode}.latency",
@@ -1208,7 +1208,7 @@
                     "name": "equinix.fabric.metro.at_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Atlanta to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.at_{metroCode}.latency",
@@ -1220,7 +1220,7 @@
                     "name": "equinix.fabric.metro.ba_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Barcelona to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.ba_{metroCode}.latency",
@@ -1232,7 +1232,7 @@
                     "name": "equinix.fabric.metro.bg_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Bogota to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.bg_{metroCode}.latency",
@@ -1244,7 +1244,7 @@
                     "name": "equinix.fabric.metro.bl_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Brussels to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.bl_{metroCode}.latency",
@@ -1256,7 +1256,7 @@
                     "name": "equinix.fabric.metro.bo_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Boston to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.bo_{metroCode}.latency",
@@ -1268,7 +1268,7 @@
                     "name": "equinix.fabric.metro.bx_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Bordeaux to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.bx_{metroCode}.latency",
@@ -1280,7 +1280,7 @@
                     "name": "equinix.fabric.metro.ca_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Canberra to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.ca_{metroCode}.latency",
@@ -1292,7 +1292,7 @@
                     "name": "equinix.fabric.metro.ch_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Chicago to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.ch_{metroCode}.latency",
@@ -1304,7 +1304,7 @@
                     "name": "equinix.fabric.metro.cl_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Calgary to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.cl_{metroCode}.latency",
@@ -1316,7 +1316,7 @@
                     "name": "equinix.fabric.metro.cu_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Culpeper to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.cu_{metroCode}.latency",
@@ -1328,7 +1328,7 @@
                     "name": "equinix.fabric.metro.da_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Dallas to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.da_{metroCode}.latency",
@@ -1340,7 +1340,7 @@
                     "name": "equinix.fabric.metro.db_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Dublin to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.db_{metroCode}.latency",
@@ -1352,7 +1352,7 @@
                     "name": "equinix.fabric.metro.dc_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Ashburn to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.dc_{metroCode}.latency",
@@ -1364,7 +1364,7 @@
                     "name": "equinix.fabric.metro.de_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Denver to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.de_{metroCode}.latency",
@@ -1376,7 +1376,7 @@
                     "name": "equinix.fabric.metro.dx_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Dubai to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.dx_{metroCode}.latency",
@@ -1388,7 +1388,7 @@
                     "name": "equinix.fabric.metro.fr_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Frankfurt to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.fr_{metroCode}.latency",
@@ -1400,7 +1400,7 @@
                     "name": "equinix.fabric.metro.gv_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Geneva to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.gv_{metroCode}.latency",
@@ -1412,7 +1412,7 @@
                     "name": "equinix.fabric.metro.he_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Helsinki to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.he_{metroCode}.latency",
@@ -1424,7 +1424,7 @@
                     "name": "equinix.fabric.metro.hh_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Hamburg to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.hh_{metroCode}.latency",
@@ -1436,7 +1436,7 @@
                     "name": "equinix.fabric.metro.hk_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Hong Kong to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.hk_{metroCode}.latency",
@@ -1448,7 +1448,7 @@
                     "name": "equinix.fabric.metro.ho_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Houston to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.ho_{metroCode}.latency",
@@ -1460,7 +1460,7 @@
                     "name": "equinix.fabric.metro.il_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Istanbul to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.il_{metroCode}.latency",
@@ -1472,7 +1472,7 @@
                     "name": "equinix.fabric.metro.jh_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Johor to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.jh_{metroCode}.latency",
@@ -1484,7 +1484,7 @@
                     "name": "equinix.fabric.metro.jk_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Jakarta to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.jk_{metroCode}.latency",
@@ -1496,7 +1496,7 @@
                     "name": "equinix.fabric.metro.jn_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Johannesburg to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.jn_{metroCode}.latency",
@@ -1508,7 +1508,7 @@
                     "name": "equinix.fabric.metro.ka_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Kamloops to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.ka_{metroCode}.latency",
@@ -1520,7 +1520,7 @@
                     "name": "equinix.fabric.metro.kl_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Kuala Lumpur to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.kl_{metroCode}.latency",
@@ -1532,7 +1532,7 @@
                     "name": "equinix.fabric.metro.la_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Los Angeles to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.la_{metroCode}.latency",
@@ -1544,7 +1544,7 @@
                     "name": "equinix.fabric.metro.ld_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from London to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.ld_{metroCode}.latency",
@@ -1556,7 +1556,7 @@
                     "name": "equinix.fabric.metro.lm_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Lima to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.lm_{metroCode}.latency",
@@ -1568,7 +1568,7 @@
                     "name": "equinix.fabric.metro.ls_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Lisbon to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.ls_{metroCode}.latency",
@@ -1580,7 +1580,7 @@
                     "name": "equinix.fabric.metro.ma_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Manchester to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.ma_{metroCode}.latency",
@@ -1592,7 +1592,7 @@
                     "name": "equinix.fabric.metro.mb_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Mumbai to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.mb_{metroCode}.latency",
@@ -1604,7 +1604,7 @@
                     "name": "equinix.fabric.metro.md_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Madrid to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.md_{metroCode}.latency",
@@ -1616,7 +1616,7 @@
                     "name": "equinix.fabric.metro.me_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Melbourne to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.me_{metroCode}.latency",
@@ -1628,7 +1628,7 @@
                     "name": "equinix.fabric.metro.mi_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Miami to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.mi_{metroCode}.latency",
@@ -1640,7 +1640,7 @@
                     "name": "equinix.fabric.metro.ml_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Milan to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.ml_{metroCode}.latency",
@@ -1652,7 +1652,7 @@
                     "name": "equinix.fabric.metro.mo_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Monterrey to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.mo_{metroCode}.latency",
@@ -1664,7 +1664,7 @@
                     "name": "equinix.fabric.metro.mt_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Montreal to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.mt_{metroCode}.latency",
@@ -1676,7 +1676,7 @@
                     "name": "equinix.fabric.metro.mu_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Munich to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.mu_{metroCode}.latency",
@@ -1688,7 +1688,7 @@
                     "name": "equinix.fabric.metro.mx_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Mexico City to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.mx_{metroCode}.latency",
@@ -1700,7 +1700,7 @@
                     "name": "equinix.fabric.metro.ny_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from New York to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.ny_{metroCode}.latency",
@@ -1712,7 +1712,7 @@
                     "name": "equinix.fabric.metro.os_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Osaka to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.os_{metroCode}.latency",
@@ -1724,7 +1724,7 @@
                     "name": "equinix.fabric.metro.ot_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Ottawa to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.ot_{metroCode}.latency",
@@ -1736,7 +1736,7 @@
                     "name": "equinix.fabric.metro.pa_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Paris to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.pa_{metroCode}.latency",
@@ -1748,7 +1748,7 @@
                     "name": "equinix.fabric.metro.pe_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Perth to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.pe_{metroCode}.latency",
@@ -1760,7 +1760,7 @@
                     "name": "equinix.fabric.metro.ph_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Philadelphia to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.ph_{metroCode}.latency",
@@ -1772,7 +1772,7 @@
                     "name": "equinix.fabric.metro.rj_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Rio de Janeiro to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.rj_{metroCode}.latency",
@@ -1784,7 +1784,7 @@
                     "name": "equinix.fabric.metro.se_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Seattle to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.se_{metroCode}.latency",
@@ -1796,7 +1796,7 @@
                     "name": "equinix.fabric.metro.sg_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Singapore to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.sg_{metroCode}.latency",
@@ -1808,7 +1808,7 @@
                     "name": "equinix.fabric.metro.sk_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Stockholm to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.sk_{metroCode}.latency",
@@ -1820,7 +1820,7 @@
                     "name": "equinix.fabric.metro.sl_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Seoul to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.sl_{metroCode}.latency",
@@ -1832,7 +1832,7 @@
                     "name": "equinix.fabric.metro.so_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Sofia to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.so_{metroCode}.latency",
@@ -1844,7 +1844,7 @@
                     "name": "equinix.fabric.metro.sp_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Sao Paulo to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.sp_{metroCode}.latency",
@@ -1856,7 +1856,7 @@
                     "name": "equinix.fabric.metro.st_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Santiago to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.st_{metroCode}.latency",
@@ -1868,7 +1868,7 @@
                     "name": "equinix.fabric.metro.sv_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Silicon Valley to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.sv_{metroCode}.latency",
@@ -1880,7 +1880,7 @@
                     "name": "equinix.fabric.metro.sy_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Sydney to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.sy_{metroCode}.latency",
@@ -1892,7 +1892,7 @@
                     "name": "equinix.fabric.metro.tr_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Toronto to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.tr_{metroCode}.latency",
@@ -1904,7 +1904,7 @@
                     "name": "equinix.fabric.metro.ty_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Tokyo to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.ty_{metroCode}.latency",
@@ -1916,7 +1916,7 @@
                     "name": "equinix.fabric.metro.va_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Vancouver to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.va_{metroCode}.latency",
@@ -1928,7 +1928,7 @@
                     "name": "equinix.fabric.metro.wa_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Warsaw to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.wa_{metroCode}.latency",
@@ -1940,7 +1940,7 @@
                     "name": "equinix.fabric.metro.wi_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Winnipeg to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.wi_{metroCode}.latency",
@@ -1952,7 +1952,7 @@
                     "name": "equinix.fabric.metro.zh_{metroCode}.jitter_avg",
                     "description": "Average metro jitter from Zurich to ${metro} is ${operator} ${operand} microseconds",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.zh_{metroCode}.latency",
@@ -2113,7 +2113,7 @@
                     "name": "equinix.fabric.metro.am_{metroCode}.jitter_avg",
                     "description": "Amsterdam to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.am_{metroCode}.latency",
@@ -2125,7 +2125,7 @@
                     "name": "equinix.fabric.metro.at_{metroCode}.jitter_avg",
                     "description": "Atlanta to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.at_{metroCode}.latency",
@@ -2137,7 +2137,7 @@
                     "name": "equinix.fabric.metro.ba_{metroCode}.jitter_avg",
                     "description": "Barcelona to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.ba_{metroCode}.latency",
@@ -2149,7 +2149,7 @@
                     "name": "equinix.fabric.metro.bg_{metroCode}.jitter_avg",
                     "description": "Bogota to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.bg_{metroCode}.latency",
@@ -2161,7 +2161,7 @@
                     "name": "equinix.fabric.metro.bl_{metroCode}.jitter_avg",
                     "description": "Brussels to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.bl_{metroCode}.latency",
@@ -2173,7 +2173,7 @@
                     "name": "equinix.fabric.metro.bo_{metroCode}.jitter_avg",
                     "description": "Boston to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.bo_{metroCode}.latency",
@@ -2185,7 +2185,7 @@
                     "name": "equinix.fabric.metro.bx_{metroCode}.jitter_avg",
                     "description": "Bordeaux to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.bx_{metroCode}.latency",
@@ -2197,7 +2197,7 @@
                     "name": "equinix.fabric.metro.ca_{metroCode}.jitter_avg",
                     "description": "Canberra to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.ca_{metroCode}.latency",
@@ -2209,7 +2209,7 @@
                     "name": "equinix.fabric.metro.ch_{metroCode}.jitter_avg",
                     "description": "Chicago to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.ch_{metroCode}.latency",
@@ -2221,7 +2221,7 @@
                     "name": "equinix.fabric.metro.cl_{metroCode}.jitter_avg",
                     "description": "Calgary to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.cl_{metroCode}.latency",
@@ -2233,7 +2233,7 @@
                     "name": "equinix.fabric.metro.cu_{metroCode}.jitter_avg",
                     "description": "Culpeper to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.cu_{metroCode}.latency",
@@ -2245,7 +2245,7 @@
                     "name": "equinix.fabric.metro.da_{metroCode}.jitter_avg",
                     "description": "Dallas to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.da_{metroCode}.latency",
@@ -2257,7 +2257,7 @@
                     "name": "equinix.fabric.metro.db_{metroCode}.jitter_avg",
                     "description": "Dublin to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.db_{metroCode}.latency",
@@ -2269,7 +2269,7 @@
                     "name": "equinix.fabric.metro.dc_{metroCode}.jitter_avg",
                     "description": "Ashburn to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.dc_{metroCode}.latency",
@@ -2281,7 +2281,7 @@
                     "name": "equinix.fabric.metro.de_{metroCode}.jitter_avg",
                     "description": "Denver to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.de_{metroCode}.latency",
@@ -2293,7 +2293,7 @@
                     "name": "equinix.fabric.metro.dx_{metroCode}.jitter_avg",
                     "description": "Dubai to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.dx_{metroCode}.latency",
@@ -2305,7 +2305,7 @@
                     "name": "equinix.fabric.metro.fr_{metroCode}.jitter_avg",
                     "description": "Frankfurt to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.fr_{metroCode}.latency",
@@ -2317,7 +2317,7 @@
                     "name": "equinix.fabric.metro.gv_{metroCode}.jitter_avg",
                     "description": "Geneva to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.gv_{metroCode}.latency",
@@ -2329,7 +2329,7 @@
                     "name": "equinix.fabric.metro.he_{metroCode}.jitter_avg",
                     "description": "Helsinki to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.he_{metroCode}.latency",
@@ -2341,7 +2341,7 @@
                     "name": "equinix.fabric.metro.hh_{metroCode}.jitter_avg",
                     "description": "Hamburg to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.hh_{metroCode}.latency",
@@ -2353,7 +2353,7 @@
                     "name": "equinix.fabric.metro.hk_{metroCode}.jitter_avg",
                     "description": "Hong Kong to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.hk_{metroCode}.latency",
@@ -2365,7 +2365,7 @@
                     "name": "equinix.fabric.metro.ho_{metroCode}.jitter_avg",
                     "description": "Houston to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.ho_{metroCode}.latency",
@@ -2377,7 +2377,7 @@
                     "name": "equinix.fabric.metro.il_{metroCode}.jitter_avg",
                     "description": "Istanbul to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.il_{metroCode}.latency",
@@ -2389,7 +2389,7 @@
                     "name": "equinix.fabric.metro.jh_{metroCode}.jitter_avg",
                     "description": "Johor to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.jh_{metroCode}.latency",
@@ -2401,7 +2401,7 @@
                     "name": "equinix.fabric.metro.jk_{metroCode}.jitter_avg",
                     "description": "Jakarta to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.jk_{metroCode}.latency",
@@ -2413,7 +2413,7 @@
                     "name": "equinix.fabric.metro.jn_{metroCode}.jitter_avg",
                     "description": "Johannesburg to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.jn_{metroCode}.latency",
@@ -2425,7 +2425,7 @@
                     "name": "equinix.fabric.metro.ka_{metroCode}.jitter_avg",
                     "description": "Kamloops to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.ka_{metroCode}.latency",
@@ -2437,7 +2437,7 @@
                     "name": "equinix.fabric.metro.kl_{metroCode}.jitter_avg",
                     "description": "Kuala Lumpur to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.kl_{metroCode}.latency",
@@ -2449,7 +2449,7 @@
                     "name": "equinix.fabric.metro.la_{metroCode}.jitter_avg",
                     "description": "Los Angeles to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.la_{metroCode}.latency",
@@ -2461,7 +2461,7 @@
                     "name": "equinix.fabric.metro.ld_{metroCode}.jitter_avg",
                     "description": "London to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.ld_{metroCode}.latency",
@@ -2473,7 +2473,7 @@
                     "name": "equinix.fabric.metro.lm_{metroCode}.jitter_avg",
                     "description": "Lima to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.lm_{metroCode}.latency",
@@ -2485,7 +2485,7 @@
                     "name": "equinix.fabric.metro.ls_{metroCode}.jitter_avg",
                     "description": "Lisbon to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.ls_{metroCode}.latency",
@@ -2497,7 +2497,7 @@
                     "name": "equinix.fabric.metro.ma_{metroCode}.jitter_avg",
                     "description": "Manchester to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.ma_{metroCode}.latency",
@@ -2509,7 +2509,7 @@
                     "name": "equinix.fabric.metro.mb_{metroCode}.jitter_avg",
                     "description": "Mumbai to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.mb_{metroCode}.latency",
@@ -2521,7 +2521,7 @@
                     "name": "equinix.fabric.metro.md_{metroCode}.jitter_avg",
                     "description": "Madrid to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.md_{metroCode}.latency",
@@ -2533,7 +2533,7 @@
                     "name": "equinix.fabric.metro.me_{metroCode}.jitter_avg",
                     "description": "Melbourne to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.me_{metroCode}.latency",
@@ -2545,7 +2545,7 @@
                     "name": "equinix.fabric.metro.mi_{metroCode}.jitter_avg",
                     "description": "Miami to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.mi_{metroCode}.latency",
@@ -2557,7 +2557,7 @@
                     "name": "equinix.fabric.metro.ml_{metroCode}.jitter_avg",
                     "description": "Milan to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.ml_{metroCode}.latency",
@@ -2569,7 +2569,7 @@
                     "name": "equinix.fabric.metro.mo_{metroCode}.jitter_avg",
                     "description": "Monterrey to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.mo_{metroCode}.latency",
@@ -2581,7 +2581,7 @@
                     "name": "equinix.fabric.metro.mt_{metroCode}.jitter_avg",
                     "description": "Montreal to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.mt_{metroCode}.latency",
@@ -2593,7 +2593,7 @@
                     "name": "equinix.fabric.metro.mu_{metroCode}.jitter_avg",
                     "description": "Munich to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.mu_{metroCode}.latency",
@@ -2605,7 +2605,7 @@
                     "name": "equinix.fabric.metro.mx_{metroCode}.jitter_avg",
                     "description": "Mexico City to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.mx_{metroCode}.latency",
@@ -2617,7 +2617,7 @@
                     "name": "equinix.fabric.metro.ny_{metroCode}.jitter_avg",
                     "description": "New York to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.ny_{metroCode}.latency",
@@ -2629,7 +2629,7 @@
                     "name": "equinix.fabric.metro.os_{metroCode}.jitter_avg",
                     "description": "Osaka to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.os_{metroCode}.latency",
@@ -2641,7 +2641,7 @@
                     "name": "equinix.fabric.metro.ot_{metroCode}.jitter_avg",
                     "description": "Ottawa to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.ot_{metroCode}.latency",
@@ -2653,7 +2653,7 @@
                     "name": "equinix.fabric.metro.pa_{metroCode}.jitter_avg",
                     "description": "Paris to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.pa_{metroCode}.latency",
@@ -2665,7 +2665,7 @@
                     "name": "equinix.fabric.metro.pe_{metroCode}.jitter_avg",
                     "description": "Perth to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.pe_{metroCode}.latency",
@@ -2677,7 +2677,7 @@
                     "name": "equinix.fabric.metro.ph_{metroCode}.jitter_avg",
                     "description": "Philadelphia to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.ph_{metroCode}.latency",
@@ -2689,7 +2689,7 @@
                     "name": "equinix.fabric.metro.rj_{metroCode}.jitter_avg",
                     "description": "Rio de Janeiro to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.rj_{metroCode}.latency",
@@ -2701,7 +2701,7 @@
                     "name": "equinix.fabric.metro.se_{metroCode}.jitter_avg",
                     "description": "Seattle to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.se_{metroCode}.latency",
@@ -2713,7 +2713,7 @@
                     "name": "equinix.fabric.metro.sg_{metroCode}.jitter_avg",
                     "description": "Singapore to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.sg_{metroCode}.latency",
@@ -2725,7 +2725,7 @@
                     "name": "equinix.fabric.metro.sk_{metroCode}.jitter_avg",
                     "description": "Stockholm to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.sk_{metroCode}.latency",
@@ -2737,7 +2737,7 @@
                     "name": "equinix.fabric.metro.sl_{metroCode}.jitter_avg",
                     "description": "Seoul to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.sl_{metroCode}.latency",
@@ -2749,7 +2749,7 @@
                     "name": "equinix.fabric.metro.so_{metroCode}.jitter_avg",
                     "description": "Sofia to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.so_{metroCode}.latency",
@@ -2761,7 +2761,7 @@
                     "name": "equinix.fabric.metro.sp_{metroCode}.jitter_avg",
                     "description": "Sao Paulo to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.sp_{metroCode}.latency",
@@ -2773,7 +2773,7 @@
                     "name": "equinix.fabric.metro.st_{metroCode}.jitter_avg",
                     "description": "Santiago to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.st_{metroCode}.latency",
@@ -2785,7 +2785,7 @@
                     "name": "equinix.fabric.metro.sv_{metroCode}.jitter_avg",
                     "description": "Silicon Valley to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.sv_{metroCode}.latency",
@@ -2797,7 +2797,7 @@
                     "name": "equinix.fabric.metro.sy_{metroCode}.jitter_avg",
                     "description": "Sydney to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.sy_{metroCode}.latency",
@@ -2809,7 +2809,7 @@
                     "name": "equinix.fabric.metro.tr_{metroCode}.jitter_avg",
                     "description": "Toronto to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.tr_{metroCode}.latency",
@@ -2821,7 +2821,7 @@
                     "name": "equinix.fabric.metro.ty_{metroCode}.jitter_avg",
                     "description": "Tokyo to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.ty_{metroCode}.latency",
@@ -2833,7 +2833,7 @@
                     "name": "equinix.fabric.metro.va_{metroCode}.jitter_avg",
                     "description": "Vancouver to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.va_{metroCode}.latency",
@@ -2845,7 +2845,7 @@
                     "name": "equinix.fabric.metro.wa_{metroCode}.jitter_avg",
                     "description": "Warsaw to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.wa_{metroCode}.latency",
@@ -2857,7 +2857,7 @@
                     "name": "equinix.fabric.metro.wi_{metroCode}.jitter_avg",
                     "description": "Winnipeg to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.wi_{metroCode}.latency",
@@ -2869,7 +2869,7 @@
                     "name": "equinix.fabric.metro.zh_{metroCode}.jitter_avg",
                     "description": "Zurich to ${metro} intermetro average jitter in microseconds",
                     "sloCategoryCode": "BROWN_METRIC_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.metro.zh_{metroCode}.latency",

--- a/jsonschema/catalog.json
+++ b/jsonschema/catalog.json
@@ -1145,18 +1145,6 @@
                     "releaseStatus": "preview"
                 },
                 {
-                    "name": "equinix.fabric.connection.byte_rx.count",
-                    "description": "Connection inbound byte count is ${operator} ${operand} MB",
-                    "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
-                },
-                {
-                    "name": "equinix.fabric.connection.byte_tx.count",
-                    "description": "Connection outbound byte count is ${operator} ${operand} MB",
-                    "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
-                },
-                {
                     "name": "equinix.fabric.connection.installed_routes_ipv4.utilization",
                     "description": "Utilization of connection active IPv4 routes is ${operator} ${operand}",
                     "sloCategoryCode": "BROWN_EVENT_SLO",
@@ -1985,18 +1973,6 @@
                     "releaseStatus": "preview"
                 },
                 {
-                    "name": "equinix.fabric.port.byte_rx.count",
-                    "description": "Port inbound byte count is ${operator} ${operand} MB",
-                    "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
-                },
-                {
-                    "name": "equinix.fabric.port.byte_tx.count",
-                    "description": "Port outbound byte count is ${operator} ${operand} MB",
-                    "sloCategoryCode": "BLUE_ALERT_SLO",
-                    "releaseStatus": "preview"
-                },
-                {
                     "name": "equinix.fabric.port.packets_dropped_rx.count",
                     "description": "Port inbound dropped packets count is ${operator} ${operand}",
                     "sloCategoryCode": "BLUE_ALERT_SLO",
@@ -2070,18 +2046,6 @@
                 {
                     "name": "equinix.fabric.connection.bandwidth_tx.utilization",
                     "description": "Connection outbound bandwidth utilization in %",
-                    "sloCategoryCode": "PURPLE_METRIC_SLO",
-                    "releaseStatus": "preview"
-                },
-                {
-                    "name": "equinix.fabric.connection.byte_rx.count",
-                    "description": "Connection inbound dropped byte count",
-                    "sloCategoryCode": "PURPLE_METRIC_SLO",
-                    "releaseStatus": "preview"
-                },
-                {
-                    "name": "equinix.fabric.connection.byte_tx.count",
-                    "description": "Connection outbound dropped byte count",
                     "sloCategoryCode": "PURPLE_METRIC_SLO",
                     "releaseStatus": "preview"
                 },
@@ -2898,18 +2862,6 @@
                 {
                     "name": "equinix.fabric.port.bandwidth_tx.utilization",
                     "description": "Port outbound bandwidth utilization in %",
-                    "sloCategoryCode": "PURPLE_METRIC_SLO",
-                    "releaseStatus": "preview"
-                },
-                {
-                    "name": "equinix.fabric.port.byte_rx.count",
-                    "description": "Port inbound dropped byte count",
-                    "sloCategoryCode": "PURPLE_METRIC_SLO",
-                    "releaseStatus": "preview"
-                },
-                {
-                    "name": "equinix.fabric.port.byte_tx.count",
-                    "description": "Port outbound dropped byte count",
                     "sloCategoryCode": "PURPLE_METRIC_SLO",
                     "releaseStatus": "preview"
                 },

--- a/jsonschema/equinix/fabric/v1/MetricAlert.json
+++ b/jsonschema/equinix/fabric/v1/MetricAlert.json
@@ -689,385 +689,385 @@
             "name": "equinix.fabric.metro.am_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Amsterdam to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.at_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Atlanta to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.ba_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Barcelona to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.bg_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Bogota to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.bl_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Brussels to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.bo_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Boston to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.bx_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Bordeaux to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.ca_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Canberra to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.ch_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Chicago to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.cl_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Calgary to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.cu_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Culpeper to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.da_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Dallas to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.db_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Dublin to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.dc_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Ashburn to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.de_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Denver to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.dx_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Dubai to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.fr_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Frankfurt to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.gv_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Geneva to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.he_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Helsinki to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.hh_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Hamburg to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.hk_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Hong Kong to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.ho_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Houston to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.il_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Istanbul to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.jh_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Johor to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.jk_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Jakarta to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.jn_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Johannesburg to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.ka_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Kamloops to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.kl_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Kuala Lumpur to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.la_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Los Angeles to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.ld_{metroCode}.jitter_avg",
             "description": "Average metro jitter from London to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.lm_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Lima to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.ls_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Lisbon to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.ma_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Manchester to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.mb_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Mumbai to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.md_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Madrid to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.me_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Melbourne to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.mi_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Miami to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.ml_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Milan to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.mo_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Monterrey to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.mt_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Montreal to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.mu_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Munich to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.mx_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Mexico City to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.ny_{metroCode}.jitter_avg",
             "description": "Average metro jitter from New York to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.os_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Osaka to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.ot_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Ottawa to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.pa_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Paris to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.pe_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Perth to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.ph_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Philadelphia to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.rj_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Rio de Janeiro to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.se_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Seattle to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.sg_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Singapore to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.sk_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Stockholm to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.sl_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Seoul to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.so_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Sofia to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.sp_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Sao Paulo to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.st_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Santiago to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.sv_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Silicon Valley to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.sy_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Sydney to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.tr_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Toronto to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.ty_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Tokyo to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.va_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Vancouver to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.wa_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Warsaw to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.wi_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Winnipeg to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.zh_{metroCode}.jitter_avg",
             "description": "Average metro jitter from Zurich to ${metro} is ${operator} ${operand} microseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         }
     ]
 }

--- a/jsonschema/equinix/fabric/v1/MetricAlert.json
+++ b/jsonschema/equinix/fabric/v1/MetricAlert.json
@@ -278,30 +278,6 @@
             "releaseStatus": "released"
         },
         {
-            "name": "equinix.fabric.connection.byte_rx.count",
-            "description": "Connection inbound byte count is ${operator} ${operand} MB",
-            "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
-        },
-        {
-            "name": "equinix.fabric.connection.byte_tx.count",
-            "description": "Connection outbound byte count is ${operator} ${operand} MB",
-            "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
-        },
-        {
-            "name": "equinix.fabric.port.byte_rx.count",
-            "description": "Port inbound byte count is ${operator} ${operand} MB",
-            "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
-        },
-        {
-            "name": "equinix.fabric.port.byte_tx.count",
-            "description": "Port outbound byte count is ${operator} ${operand} MB",
-            "sloCategoryCode": "BLUE_ALERT_SLO",
-            "releaseStatus": "preview"
-        },
-        {
             "name": "equinix.fabric.metro.am_{metroCode}.latency",
             "description": "Metro latency from Amsterdam to ${metro} is ${operator} ${operand} milliseconds",
             "sloCategoryCode": "BLUE_ALERT_SLO",

--- a/jsonschema/equinix/fabric/v1/MetricEvent.json
+++ b/jsonschema/equinix/fabric/v1/MetricEvent.json
@@ -639,385 +639,385 @@
             "name": "equinix.fabric.metro.am_{metroCode}.jitter_avg",
             "description": "Amsterdam to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.at_{metroCode}.jitter_avg",
             "description": "Atlanta to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.ba_{metroCode}.jitter_avg",
             "description": "Barcelona to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.bg_{metroCode}.jitter_avg",
             "description": "Bogota to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.bl_{metroCode}.jitter_avg",
             "description": "Brussels to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.bo_{metroCode}.jitter_avg",
             "description": "Boston to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.bx_{metroCode}.jitter_avg",
             "description": "Bordeaux to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.ca_{metroCode}.jitter_avg",
             "description": "Canberra to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.ch_{metroCode}.jitter_avg",
             "description": "Chicago to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.cl_{metroCode}.jitter_avg",
             "description": "Calgary to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.cu_{metroCode}.jitter_avg",
             "description": "Culpeper to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.da_{metroCode}.jitter_avg",
             "description": "Dallas to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.db_{metroCode}.jitter_avg",
             "description": "Dublin to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.dc_{metroCode}.jitter_avg",
             "description": "Ashburn to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.de_{metroCode}.jitter_avg",
             "description": "Denver to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.dx_{metroCode}.jitter_avg",
             "description": "Dubai to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.fr_{metroCode}.jitter_avg",
             "description": "Frankfurt to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.gv_{metroCode}.jitter_avg",
             "description": "Geneva to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.he_{metroCode}.jitter_avg",
             "description": "Helsinki to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.hh_{metroCode}.jitter_avg",
             "description": "Hamburg to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.hk_{metroCode}.jitter_avg",
             "description": "Hong Kong to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.ho_{metroCode}.jitter_avg",
             "description": "Houston to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.il_{metroCode}.jitter_avg",
             "description": "Istanbul to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.jh_{metroCode}.jitter_avg",
             "description": "Johor to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.jk_{metroCode}.jitter_avg",
             "description": "Jakarta to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.jn_{metroCode}.jitter_avg",
             "description": "Johannesburg to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.ka_{metroCode}.jitter_avg",
             "description": "Kamloops to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.kl_{metroCode}.jitter_avg",
             "description": "Kuala Lumpur to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.la_{metroCode}.jitter_avg",
             "description": "Los Angeles to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.ld_{metroCode}.jitter_avg",
             "description": "London to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.lm_{metroCode}.jitter_avg",
             "description": "Lima to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.ls_{metroCode}.jitter_avg",
             "description": "Lisbon to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.ma_{metroCode}.jitter_avg",
             "description": "Manchester to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.mb_{metroCode}.jitter_avg",
             "description": "Mumbai to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.md_{metroCode}.jitter_avg",
             "description": "Madrid to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.me_{metroCode}.jitter_avg",
             "description": "Melbourne to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.mi_{metroCode}.jitter_avg",
             "description": "Miami to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.ml_{metroCode}.jitter_avg",
             "description": "Milan to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.mo_{metroCode}.jitter_avg",
             "description": "Monterrey to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.mt_{metroCode}.jitter_avg",
             "description": "Montreal to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.mu_{metroCode}.jitter_avg",
             "description": "Munich to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.mx_{metroCode}.jitter_avg",
             "description": "Mexico City to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.ny_{metroCode}.jitter_avg",
             "description": "New York to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.os_{metroCode}.jitter_avg",
             "description": "Osaka to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.ot_{metroCode}.jitter_avg",
             "description": "Ottawa to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.pa_{metroCode}.jitter_avg",
             "description": "Paris to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.pe_{metroCode}.jitter_avg",
             "description": "Perth to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.ph_{metroCode}.jitter_avg",
             "description": "Philadelphia to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.rj_{metroCode}.jitter_avg",
             "description": "Rio de Janeiro to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.se_{metroCode}.jitter_avg",
             "description": "Seattle to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.sg_{metroCode}.jitter_avg",
             "description": "Singapore to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.sk_{metroCode}.jitter_avg",
             "description": "Stockholm to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.sl_{metroCode}.jitter_avg",
             "description": "Seoul to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.so_{metroCode}.jitter_avg",
             "description": "Sofia to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.sp_{metroCode}.jitter_avg",
             "description": "Sao Paulo to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.st_{metroCode}.jitter_avg",
             "description": "Santiago to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.sv_{metroCode}.jitter_avg",
             "description": "Silicon Valley to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.sy_{metroCode}.jitter_avg",
             "description": "Sydney to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.tr_{metroCode}.jitter_avg",
             "description": "Toronto to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.ty_{metroCode}.jitter_avg",
             "description": "Tokyo to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.va_{metroCode}.jitter_avg",
             "description": "Vancouver to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.wa_{metroCode}.jitter_avg",
             "description": "Warsaw to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.wi_{metroCode}.jitter_avg",
             "description": "Winnipeg to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.metro.zh_{metroCode}.jitter_avg",
             "description": "Zurich to ${metro} intermetro average jitter in microseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         }
     ],
     "alertNames": []

--- a/jsonschema/equinix/fabric/v1/MetricEvent.json
+++ b/jsonschema/equinix/fabric/v1/MetricEvent.json
@@ -228,30 +228,6 @@
             "releaseStatus": "released"
         },
         {
-            "name": "equinix.fabric.connection.byte_rx.count",
-            "description": "Connection inbound dropped byte count",
-            "sloCategoryCode": "PURPLE_METRIC_SLO",
-            "releaseStatus": "preview"
-        },
-        {
-            "name": "equinix.fabric.connection.byte_tx.count",
-            "description": "Connection outbound dropped byte count",
-            "sloCategoryCode": "PURPLE_METRIC_SLO",
-            "releaseStatus": "preview"
-        },
-        {
-            "name": "equinix.fabric.port.byte_rx.count",
-            "description": "Port inbound dropped byte count",
-            "sloCategoryCode": "PURPLE_METRIC_SLO",
-            "releaseStatus": "preview"
-        },
-        {
-            "name": "equinix.fabric.port.byte_tx.count",
-            "description": "Port outbound dropped byte count",
-            "sloCategoryCode": "PURPLE_METRIC_SLO",
-            "releaseStatus": "preview"
-        },
-        {
             "name": "equinix.fabric.metro.am_{metroCode}.latency",
             "description": "Amsterdam to ${metro} intermetro latency, average in milliseconds",
             "sloCategoryCode": "BROWN_METRIC_SLO",


### PR DESCRIPTION
## Checklist
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I certify that my `preview` and `released` lists for Events/Metrics/Alerts are correct
- [x] I certify that all Events/Metrics/Alerts in `released` are properly tested and ready for production
