### PR TITLE
Adding cloud event types to support Phase 2 ESH notifications

### DIFF
--- a/DataLoader.json
+++ b/DataLoader.json
@@ -738,6 +738,31 @@
                 "releaseStatus": "released"
             },
             {
+                "name": "equinix.network.maintenance.state.cancelled",
+                "description": "Network maintenance state changed to cancelled",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.network.maintenance.state.completed",
+                "description": "Network maintenance state changed to completed",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.network.maintenance.state.confirmed",
+                "description": "Network maintenance state changed to confirmed",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.network.maintenance.state.extended",
+                "description": "Network maintenance state changed to extended",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.network.maintenance.state.rescheduled",
+                "description": "Network maintenance state changed to rescheduled",
+                "releaseStatus": "released"
+            },
+            {
                 "name": "equinix.network.repair.state.cancelled",
                 "description": "Network repair state changed to cancelled",
                 "releaseStatus": "released"
@@ -878,33 +903,8 @@
                 "releaseStatus": "preview"
             },
             {
-                "name": "equinix.network.maintenance.state.cancelled",
-                "description": "Network maintenance state changed to cancelled",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.network.maintenance.state.completed",
-                "description": "Network maintenance state changed to completed",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.network.maintenance.state.confirmed",
-                "description": "Network maintenance state changed to confirmed",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.network.maintenance.state.extended",
-                "description": "Network maintenance state changed to extended",
-                "releaseStatus": "preview"
-            },
-            {
                 "name": "equinix.network.maintenance.state.in_progress",
                 "description": "Network maintenance state changed to in_progress",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.network.maintenance.state.rescheduled",
-                "description": "Network maintenance state changed to rescheduled",
                 "releaseStatus": "preview"
             },
             {

--- a/DataLoader.json
+++ b/DataLoader.json
@@ -738,56 +738,6 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.network.maintenance.state.cancelled",
-                "description": "Network maintenance state changed to cancelled",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.network.maintenance.state.completed",
-                "description": "Network maintenance state changed to completed",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.network.maintenance.state.confirmed",
-                "description": "Network maintenance state changed to confirmed",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.network.maintenance.state.extended",
-                "description": "Network maintenance state changed to extended",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.network.maintenance.state.rescheduled",
-                "description": "Network maintenance state changed to rescheduled",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.network.repair.state.cancelled",
-                "description": "Network repair state changed to cancelled",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.network.repair.state.confirmed",
-                "description": "Network repair state changed to confirmed",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.network.repair.state.in_progress",
-                "description": "Network repair state changed to in_progress",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.network.repair.state.rescheduled",
-                "description": "Network repair state changed to rescheduled",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.network.repair.state.resolved",
-                "description": "Network repair state changed to resolved",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.ip_block.state.deprovisioned",
                 "description": "Ip Block deprovisioned",
                 "releaseStatus": "preview"
@@ -900,16 +850,6 @@
             {
                 "name": "equinix.fabric.tunnel_bgpipv6_session.status.open_sent",
                 "description": "BGP peer ${ipv6_address} (AS ${asn}) session open_sent",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.network.maintenance.state.in_progress",
-                "description": "Network maintenance state changed to in_progress",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.network.repair.state.completed",
-                "description": "Network repair state changed to completed",
                 "releaseStatus": "preview"
             }
         ],
@@ -2495,6 +2435,72 @@
             {
                 "name": "equinix.fabric.metro_connect.state.reprovisioning",
                 "description": "Metro Connect is reprovisioning",
+                "releaseStatus": "preview"
+            }
+        ],
+        "metricNames": [],
+        "alertNames": []
+    },
+    "network": {
+        "cloudeventTypes": [
+            {
+                "name": "equinix.network.maintenance.state.cancelled",
+                "description": "Network maintenance state changed to cancelled",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.network.maintenance.state.completed",
+                "description": "Network maintenance state changed to completed",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.network.maintenance.state.confirmed",
+                "description": "Network maintenance state changed to confirmed",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.network.maintenance.state.extended",
+                "description": "Network maintenance state changed to extended",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.network.maintenance.state.rescheduled",
+                "description": "Network maintenance state changed to rescheduled",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.network.repair.state.cancelled",
+                "description": "Network repair state changed to cancelled",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.network.repair.state.confirmed",
+                "description": "Network repair state changed to confirmed",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.network.repair.state.in_progress",
+                "description": "Network repair state changed to in_progress",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.network.repair.state.rescheduled",
+                "description": "Network repair state changed to rescheduled",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.network.repair.state.resolved",
+                "description": "Network repair state changed to resolved",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.network.maintenance.state.in_progress",
+                "description": "Network maintenance state changed to in_progress",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.network.repair.state.completed",
+                "description": "Network repair state changed to completed",
                 "releaseStatus": "preview"
             }
         ],

--- a/README.md
+++ b/README.md
@@ -1112,25 +1112,25 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.network.maintenance.state.cancelled</td>
 		<td>Network maintenance state changed to cancelled</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.network.maintenance.state.completed</td>
 		<td>Network maintenance state changed to completed</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.network.maintenance.state.confirmed</td>
 		<td>Network maintenance state changed to confirmed</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.network.maintenance.state.extended</td>
 		<td>Network maintenance state changed to extended</td>
-		<td>preview</td>
+		<td>released</td>
 	<td>-</td>
 	</tr>
 	<tr>
@@ -1142,7 +1142,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.network.maintenance.state.rescheduled</td>
 		<td>Network maintenance state changed to rescheduled</td>
-		<td>preview</td>
+		<td>released</td>
 	<td>-</td>
 	</tr>
 	<tr>

--- a/README.md
+++ b/README.md
@@ -1095,97 +1095,6 @@ The following data payloads are the supported events and formats for Equinix Net
 
 
 ---
-### Equinix Fabric Incident
-#### DataSchema [JSON](https://equinix.github.io/equinix-cloudevents/jsonschema/equinix/fabric/v1/Incident.json)
-#### Data Type
-`equinix.fabric.v1.Incident`
-#### Supported Events, Metrics, and Alerts
-#### Events
-
-<table>
-	<tr>
-		<th>Name</th>
-		<th>Description</th>
-		<th>Release Status</th>
-		<th>SLO Category</th>
-	</tr>
-	<tr>
-		<td>equinix.network.maintenance.state.cancelled</td>
-		<td>Network maintenance state changed to cancelled</td>
-		<td>released</td>
-	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
-	</tr>
-	<tr>
-		<td>equinix.network.maintenance.state.completed</td>
-		<td>Network maintenance state changed to completed</td>
-		<td>released</td>
-	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
-	</tr>
-	<tr>
-		<td>equinix.network.maintenance.state.confirmed</td>
-		<td>Network maintenance state changed to confirmed</td>
-		<td>released</td>
-	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
-	</tr>
-	<tr>
-		<td>equinix.network.maintenance.state.extended</td>
-		<td>Network maintenance state changed to extended</td>
-		<td>released</td>
-	<td>-</td>
-	</tr>
-	<tr>
-		<td>equinix.network.maintenance.state.in_progress</td>
-		<td>Network maintenance state changed to in_progress</td>
-		<td>preview</td>
-	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
-	</tr>
-	<tr>
-		<td>equinix.network.maintenance.state.rescheduled</td>
-		<td>Network maintenance state changed to rescheduled</td>
-		<td>released</td>
-	<td>-</td>
-	</tr>
-	<tr>
-		<td>equinix.network.repair.state.cancelled</td>
-		<td>Network repair state changed to cancelled</td>
-		<td>released</td>
-	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
-	</tr>
-	<tr>
-		<td>equinix.network.repair.state.completed</td>
-		<td>Network repair state changed to completed</td>
-		<td>preview</td>
-	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
-	</tr>
-	<tr>
-		<td>equinix.network.repair.state.confirmed</td>
-		<td>Network repair state changed to confirmed</td>
-		<td>released</td>
-	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
-	</tr>
-	<tr>
-		<td>equinix.network.repair.state.in_progress</td>
-		<td>Network repair state changed to in_progress</td>
-		<td>released</td>
-	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
-	</tr>
-	<tr>
-		<td>equinix.network.repair.state.rescheduled</td>
-		<td>Network repair state changed to rescheduled</td>
-		<td>released</td>
-	<td>-</td>
-	</tr>
-	<tr>
-		<td>equinix.network.repair.state.resolved</td>
-		<td>Network repair state changed to resolved</td>
-		<td>released</td>
-	<td>-</td>
-	</tr>
-</table>
-
-
-
----
 ### Equinix Fabric MetricAlert
 #### DataSchema [JSON](https://equinix.github.io/equinix-cloudevents/jsonschema/equinix/fabric/v1/MetricAlert.json)
 #### Data Type
@@ -4048,6 +3957,97 @@ The following data payloads are the supported events and formats for Equinix Net
 		<td>Metro Connect is reprovisioning</td>
 		<td>preview</td>
 	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
+	</tr>
+</table>
+
+
+
+---
+### Equinix Network Notification Event
+#### DataSchema [JSON](https://equinix.github.io/equinix-cloudevents/jsonschema/equinix/network/v1/NotificationEvent.json)
+#### Data Type
+`equinix.network.v1.Notification Event`
+#### Supported Events, Metrics, and Alerts
+#### Events
+
+<table>
+	<tr>
+		<th>Name</th>
+		<th>Description</th>
+		<th>Release Status</th>
+		<th>SLO Category</th>
+	</tr>
+	<tr>
+		<td>equinix.network.maintenance.state.cancelled</td>
+		<td>Network maintenance state changed to cancelled</td>
+		<td>released</td>
+	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
+	</tr>
+	<tr>
+		<td>equinix.network.maintenance.state.completed</td>
+		<td>Network maintenance state changed to completed</td>
+		<td>released</td>
+	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
+	</tr>
+	<tr>
+		<td>equinix.network.maintenance.state.confirmed</td>
+		<td>Network maintenance state changed to confirmed</td>
+		<td>released</td>
+	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
+	</tr>
+	<tr>
+		<td>equinix.network.maintenance.state.extended</td>
+		<td>Network maintenance state changed to extended</td>
+		<td>released</td>
+	<td>-</td>
+	</tr>
+	<tr>
+		<td>equinix.network.maintenance.state.in_progress</td>
+		<td>Network maintenance state changed to in_progress</td>
+		<td>preview</td>
+	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
+	</tr>
+	<tr>
+		<td>equinix.network.maintenance.state.rescheduled</td>
+		<td>Network maintenance state changed to rescheduled</td>
+		<td>released</td>
+	<td>-</td>
+	</tr>
+	<tr>
+		<td>equinix.network.repair.state.cancelled</td>
+		<td>Network repair state changed to cancelled</td>
+		<td>released</td>
+	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
+	</tr>
+	<tr>
+		<td>equinix.network.repair.state.completed</td>
+		<td>Network repair state changed to completed</td>
+		<td>preview</td>
+	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
+	</tr>
+	<tr>
+		<td>equinix.network.repair.state.confirmed</td>
+		<td>Network repair state changed to confirmed</td>
+		<td>released</td>
+	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
+	</tr>
+	<tr>
+		<td>equinix.network.repair.state.in_progress</td>
+		<td>Network repair state changed to in_progress</td>
+		<td>released</td>
+	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
+	</tr>
+	<tr>
+		<td>equinix.network.repair.state.rescheduled</td>
+		<td>Network repair state changed to rescheduled</td>
+		<td>released</td>
+	<td>-</td>
+	</tr>
+	<tr>
+		<td>equinix.network.repair.state.resolved</td>
+		<td>Network repair state changed to resolved</td>
+		<td>released</td>
+	<td>-</td>
 	</tr>
 </table>
 

--- a/jsonschema/catalog.json
+++ b/jsonschema/catalog.json
@@ -1043,24 +1043,24 @@
                     "name": "equinix.network.maintenance.state.cancelled",
                     "description": "Network maintenance state changed to cancelled",
                     "sloCategoryCode": "BLUE_EVENT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.network.maintenance.state.completed",
                     "description": "Network maintenance state changed to completed",
                     "sloCategoryCode": "BLUE_EVENT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.network.maintenance.state.confirmed",
                     "description": "Network maintenance state changed to confirmed",
                     "sloCategoryCode": "BLUE_EVENT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.network.maintenance.state.extended",
                     "description": "Network maintenance state changed to extended",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.network.maintenance.state.in_progress",
@@ -1071,7 +1071,7 @@
                 {
                     "name": "equinix.network.maintenance.state.rescheduled",
                     "description": "Network maintenance state changed to rescheduled",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.network.repair.state.cancelled",

--- a/jsonschema/catalog.json
+++ b/jsonschema/catalog.json
@@ -1033,85 +1033,6 @@
             "alertNames": []
         },
         {
-            "url": "https://equinix.github.io/equinix-cloudevents/jsonschema/equinix/fabric/v1/Incident.json",
-            "domain": "Equinix Fabric Incident",
-            "name": "Incident",
-            "description": "The data within all Incident events",
-            "datatype": "equinix.fabric.v1.Incident",
-            "cloudeventTypes": [
-                {
-                    "name": "equinix.network.maintenance.state.cancelled",
-                    "description": "Network maintenance state changed to cancelled",
-                    "sloCategoryCode": "BLUE_EVENT_SLO",
-                    "releaseStatus": "released"
-                },
-                {
-                    "name": "equinix.network.maintenance.state.completed",
-                    "description": "Network maintenance state changed to completed",
-                    "sloCategoryCode": "BLUE_EVENT_SLO",
-                    "releaseStatus": "released"
-                },
-                {
-                    "name": "equinix.network.maintenance.state.confirmed",
-                    "description": "Network maintenance state changed to confirmed",
-                    "sloCategoryCode": "BLUE_EVENT_SLO",
-                    "releaseStatus": "released"
-                },
-                {
-                    "name": "equinix.network.maintenance.state.extended",
-                    "description": "Network maintenance state changed to extended",
-                    "releaseStatus": "released"
-                },
-                {
-                    "name": "equinix.network.maintenance.state.in_progress",
-                    "description": "Network maintenance state changed to in_progress",
-                    "sloCategoryCode": "BLUE_EVENT_SLO",
-                    "releaseStatus": "preview"
-                },
-                {
-                    "name": "equinix.network.maintenance.state.rescheduled",
-                    "description": "Network maintenance state changed to rescheduled",
-                    "releaseStatus": "released"
-                },
-                {
-                    "name": "equinix.network.repair.state.cancelled",
-                    "description": "Network repair state changed to cancelled",
-                    "sloCategoryCode": "BLUE_EVENT_SLO",
-                    "releaseStatus": "released"
-                },
-                {
-                    "name": "equinix.network.repair.state.completed",
-                    "description": "Network repair state changed to completed",
-                    "sloCategoryCode": "BLUE_EVENT_SLO",
-                    "releaseStatus": "preview"
-                },
-                {
-                    "name": "equinix.network.repair.state.confirmed",
-                    "description": "Network repair state changed to confirmed",
-                    "sloCategoryCode": "BLUE_EVENT_SLO",
-                    "releaseStatus": "released"
-                },
-                {
-                    "name": "equinix.network.repair.state.in_progress",
-                    "description": "Network repair state changed to in_progress",
-                    "sloCategoryCode": "BLUE_EVENT_SLO",
-                    "releaseStatus": "released"
-                },
-                {
-                    "name": "equinix.network.repair.state.rescheduled",
-                    "description": "Network repair state changed to rescheduled",
-                    "releaseStatus": "released"
-                },
-                {
-                    "name": "equinix.network.repair.state.resolved",
-                    "description": "Network repair state changed to resolved",
-                    "releaseStatus": "released"
-                }
-            ],
-            "metricNames": [],
-            "alertNames": []
-        },
-        {
             "url": "https://equinix.github.io/equinix-cloudevents/jsonschema/equinix/fabric/v1/MetricAlert.json",
             "domain": "Equinix Fabric MetricAlert",
             "name": "MetricAlert",
@@ -3876,6 +3797,85 @@
                     "description": "Metro Connect is reprovisioning",
                     "sloCategoryCode": "BLUE_EVENT_SLO",
                     "releaseStatus": "preview"
+                }
+            ],
+            "metricNames": [],
+            "alertNames": []
+        },
+        {
+            "url": "https://equinix.github.io/equinix-cloudevents/jsonschema/equinix/network/v1/NotificationEvent.json",
+            "domain": "Equinix Network Notification Event",
+            "name": "Notification Event",
+            "description": "The data within all Notification Events",
+            "datatype": "equinix.network.v1.Notification Event",
+            "cloudeventTypes": [
+                {
+                    "name": "equinix.network.maintenance.state.cancelled",
+                    "description": "Network maintenance state changed to cancelled",
+                    "sloCategoryCode": "BLUE_EVENT_SLO",
+                    "releaseStatus": "released"
+                },
+                {
+                    "name": "equinix.network.maintenance.state.completed",
+                    "description": "Network maintenance state changed to completed",
+                    "sloCategoryCode": "BLUE_EVENT_SLO",
+                    "releaseStatus": "released"
+                },
+                {
+                    "name": "equinix.network.maintenance.state.confirmed",
+                    "description": "Network maintenance state changed to confirmed",
+                    "sloCategoryCode": "BLUE_EVENT_SLO",
+                    "releaseStatus": "released"
+                },
+                {
+                    "name": "equinix.network.maintenance.state.extended",
+                    "description": "Network maintenance state changed to extended",
+                    "releaseStatus": "released"
+                },
+                {
+                    "name": "equinix.network.maintenance.state.in_progress",
+                    "description": "Network maintenance state changed to in_progress",
+                    "sloCategoryCode": "BLUE_EVENT_SLO",
+                    "releaseStatus": "preview"
+                },
+                {
+                    "name": "equinix.network.maintenance.state.rescheduled",
+                    "description": "Network maintenance state changed to rescheduled",
+                    "releaseStatus": "released"
+                },
+                {
+                    "name": "equinix.network.repair.state.cancelled",
+                    "description": "Network repair state changed to cancelled",
+                    "sloCategoryCode": "BLUE_EVENT_SLO",
+                    "releaseStatus": "released"
+                },
+                {
+                    "name": "equinix.network.repair.state.completed",
+                    "description": "Network repair state changed to completed",
+                    "sloCategoryCode": "BLUE_EVENT_SLO",
+                    "releaseStatus": "preview"
+                },
+                {
+                    "name": "equinix.network.repair.state.confirmed",
+                    "description": "Network repair state changed to confirmed",
+                    "sloCategoryCode": "BLUE_EVENT_SLO",
+                    "releaseStatus": "released"
+                },
+                {
+                    "name": "equinix.network.repair.state.in_progress",
+                    "description": "Network repair state changed to in_progress",
+                    "sloCategoryCode": "BLUE_EVENT_SLO",
+                    "releaseStatus": "released"
+                },
+                {
+                    "name": "equinix.network.repair.state.rescheduled",
+                    "description": "Network repair state changed to rescheduled",
+                    "releaseStatus": "released"
+                },
+                {
+                    "name": "equinix.network.repair.state.resolved",
+                    "description": "Network repair state changed to resolved",
+                    "releaseStatus": "released"
                 }
             ],
             "metricNames": [],

--- a/jsonschema/equinix/fabric/v1/Incident.json
+++ b/jsonschema/equinix/fabric/v1/Incident.json
@@ -127,7 +127,7 @@
       "name": "equinix.network.maintenance.state.confirmed",
       "description": "Network maintenance state changed to confirmed",
       "sloCategoryCode": "BLUE_EVENT_SLO",
-      "releaseStatus": "preview"
+      "releaseStatus": "released"
     },
     {
       "name": "equinix.network.maintenance.state.in_progress",
@@ -139,23 +139,23 @@
       "name": "equinix.network.maintenance.state.cancelled",
       "description": "Network maintenance state changed to cancelled",
       "sloCategoryCode": "BLUE_EVENT_SLO",
-      "releaseStatus": "preview"
+      "releaseStatus": "released"
     },
     {
       "name": "equinix.network.maintenance.state.completed",
       "description": "Network maintenance state changed to completed",
       "sloCategoryCode": "BLUE_EVENT_SLO",
-      "releaseStatus": "preview"
+      "releaseStatus": "released"
     },
     {
       "name": "equinix.network.maintenance.state.extended",
       "description": "Network maintenance state changed to extended",
-      "releaseStatus": "preview"
+      "releaseStatus": "released"
     },
     {
       "name": "equinix.network.maintenance.state.rescheduled",
       "description": "Network maintenance state changed to rescheduled",
-      "releaseStatus": "preview"
+      "releaseStatus": "released"
     },
     {
       "name": "equinix.network.repair.state.confirmed",

--- a/jsonschema/equinix/network/v1/NotificationEvent.json
+++ b/jsonschema/equinix/network/v1/NotificationEvent.json
@@ -1,10 +1,10 @@
 {
-  "$id": "https://equinix.github.io/equinix-cloudevents/jsonschema/equinix/fabric/v1/Incident.json",
-  "name": "Incident",
+  "$id": "https://equinix.github.io/equinix-cloudevents/jsonschema/equinix/network/v1/NotificationEvent.json",
+  "name": "Notification Event",
   "examples": [],
-  "package": "equinix.fabric.v1",
-  "datatype": "equinix.fabric.v1.Incident",
-  "domain": "Equinix Fabric Incident",
+  "package": "equinix.network.v1",
+  "datatype": "equinix.network.v1.Notification Event",
+  "domain": "Equinix Network Notification Event",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "$ref": "#/definitions/Data",
   "definitions": {
@@ -17,18 +17,18 @@
         },
         "message": {
           "type": "string",
-          "description": "Supporting message describing the incident event"
+          "description": "Supporting message describing the notification event"
         },
         "auth": {
           "$ref": "#/definitions/Auth",
           "additionalProperties": true,
-          "description": "The auth context within all incident event"
+          "description": "The auth context within all notification event"
         }
       },
       "additionalProperties": true,
       "type": "object",
-      "title": "Incident Event Data",
-      "description": "The data within all Incident events"
+      "title": "Notification Event Data",
+      "description": "The data within all Notification Events"
     },
     "Auth": {
       "properties": {
@@ -40,45 +40,45 @@
       "additionalProperties": true,
       "type": "object",
       "title": "Auth",
-      "description": "Auth information of the generated Incident event"
+      "description": "Auth information of the generated Notification Event"
     },
     "Resource": {
       "properties": {
         "type": {
           "type": "string",
-          "description": "Type of the incident (e.g., maintenance or repair)"
+          "description": "Type of the notification event (e.g., maintenance or repair)"
         },
         "uuid": {
           "type": "string",
-          "description": "Equinix assigned unique identifier of the incident"
+          "description": "Equinix assigned unique identifier of the notification event"
         },
         "state": {
           "type": "string",
-          "description": "State of the maintenance/repair incident"
+          "description": "State of the maintenance/repair notification event"
         },
         "description": {
           "type": "string",
-          "description": "Description of the maintenance/repair incident"
+          "description": "Description of the maintenance/repair notification event"
         },
         "servicerId": {
           "type": "string",
-          "description": "Servicer ID for the maintenance/repair incident"
+          "description": "Servicer ID for the maintenance/repair notification event"
         },
         "startDateTime": {
           "type": "string",
-          "description": "Start date and time of the maintenance/repair incident"
+          "description": "Start date and time of the maintenance/repair notification event"
         },
         "endDateTime": {
           "type": "string",
-          "description": "End date and time of the maintenance/repair incident"
+          "description": "End date and time of the maintenance/repair notification event"
         },
         "accountNumber": {
           "type": "string",
-          "description": "Account number associated with the maintenance/repair incident"
+          "description": "Account number associated with the maintenance/repair notification event"
         },
         "impact": {
           "type": "string",
-          "description": "Impact of the maintenance/repair incident"
+          "description": "Impact of the maintenance/repair notification event"
         },
         "prodID": {
           "type": "string",
@@ -86,40 +86,40 @@
         },
         "organizer": {
           "type": "string",
-          "description": "Organizer of the maintenance/repair incident"
+          "description": "Organizer of the maintenance/repair notification event"
         },
         "assets": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/Asset"
           },
-          "description": "List of assets affected by the maintenance/repair incident"
+          "description": "List of assets affected by the maintenance/repair notification event"
         }
       },
       "additionalProperties": true,
       "type": "object",
       "title": "Resource",
-      "description": "Schema of the resource that fired the incident event"
+      "description": "Schema of the resource that fired the notification event"
     },
     "Asset": {
       "properties": {
         "href": {
           "type": "string",
-          "description": "Link to the asset affected by the maintenance/repair incident"
+          "description": "Link to the asset affected by the maintenance/repair notification event"
         },
         "type": {
           "type": "string",
-          "description": "Type of the asset affected by the maintenance/repair incident"
+          "description": "Type of the asset affected by the maintenance/repair notification event"
         },
         "uuid": {
           "type": "string",
-          "description": "Unique identifier of the asset affected by the maintenance/repair incident"
+          "description": "Unique identifier of the asset affected by the maintenance/repair notification event"
         }
       },
       "additionalProperties": true,
       "type": "object",
       "title": "Asset",
-      "description": "Schema of an asset affected by the maintenance/repair incident"
+      "description": "Schema of an asset affected by the maintenance/repair notification event"
     }
   },
   "cloudeventTypes": [


### PR DESCRIPTION
## Checklist
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I certify that my `preview` and `released` lists for Events/Metrics/Alerts are correct
- [x] I certify that all Events/Metrics/Alerts in `released` are properly tested and ready for production
