### PR TITLE
Add App Connect preview cloud events

### DIFF
--- a/jsonschema/equinix/fabric/v1/ChangeEvent.json
+++ b/jsonschema/equinix/fabric/v1/ChangeEvent.json
@@ -1193,6 +1193,120 @@
             "description": "Service Profile Connection ${connection_name} state changed to deprovisioned",
             "sloCategoryCode": "BLUE_EVENT_SLO",
             "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.app_subscription.state.provisioning",
+            "description": "Application Subscription is provisioning",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.app_subscription.state.provisioned",
+            "description": "Application Subscription is provisioned",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.app_subscription.state.provisioning_failed",
+            "description": "Application Subscription provisioning failed",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.app_subscription.state.deprovisioning",
+            "description": "Application Subscription is deprovisioning",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.app_subscription.state.deprovisioned",
+            "description": "Application Subscription is deprovisioned",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.app_subscription.state.deprovisioning_failed",
+            "description": "Application Subscription deprovisioning failed",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.app_domain.state.pending_verification",
+            "description": "Application Domain verification is pending",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.app_domain.state.provisioned",
+            "description": "Application Domain is provisioned",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.app_domain.state.deprovisioned",
+            "description": "Application Domain is deprovisioned",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.app_domain.state.provisioning_failed",
+            "description": "Application Domain provisioning failed",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.app_domain.state.deprovisioning_failed",
+            "description": "Application Domain deprovisioning failed",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.app_link.state.provisioning",
+            "description": "Application Link is provisioning",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.app_link.state.provisioned",
+            "description": "Application Link is provisioned",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.app_link.state.provisioning_failed",
+            "description": "Application Link provisioning failed",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.app_link.state.deprovisioning",
+            "description": "Application Link is deprovisioning",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.app_link.state.deprovisioned",
+            "description": "Application Link is deprovisioned",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.app_link.state.deprovisioning_failed",
+            "description": "Application Link deprovisioning failed",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.app_service.state.provisioned",
+            "description": "Application Service is provisioned",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.app_service.state.deprovisioned",
+            "description": "Application Service is deprovisioned",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
         }
     ],
     "metricNames": [],


### PR DESCRIPTION
## Summary
Registers new **preview** `ChangeEvent` cloud event types for four Fabric **App Connect** resource families. All 19 types are added as `preview` (DEV-only) per `CONTRIBUTING.md`, sharing the existing fabric ChangeEvent data schema. Only `jsonschema/equinix/fabric/v1/ChangeEvent.json` is edited; generated artifacts (`DataLoader.json`, `catalog.json`, `README.md`) are produced by the sync workflow.

New event types (all `preview`, `BLUE_EVENT_SLO`):

- **app_subscription** (6): provisioning, provisioned, provisioning_failed, deprovisioning, deprovisioned, deprovisioning_failed
- **app_domain** (5): pending_verification, provisioned, deprovisioned, provisioning_failed, deprovisioning_failed
- **app_link** (6): provisioning, provisioned, provisioning_failed, deprovisioning, deprovisioned, deprovisioning_failed
- **app_service** (2): provisioned, deprovisioned

Validated locally with `scripts/validate_json_schemas.py` (passed) and confirmed all 19 entries generate into the downstream artifacts.

## Checklist
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I certify that my `preview` and `released` lists for Events/Metrics/Alerts are correct
- [x] I certify that all Events/Metrics/Alerts in `released` are properly tested and ready for production

🤖 Generated with [Claude Code](https://claude.com/claude-code)