### PR TITLE
ApplicationConnect cloud events in preview

### DIFF
--- a/DataLoader.json
+++ b/DataLoader.json
@@ -773,6 +773,101 @@
                 "releaseStatus": "released"
             },
             {
+                "name": "equinix.fabric.app_domain.state.deprovisioned",
+                "description": "Application Domain is deprovisioned",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.app_domain.state.deprovisioning_failed",
+                "description": "Application Domain deprovisioning failed",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.app_domain.state.pending_verification",
+                "description": "Application Domain verification is pending",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.app_domain.state.provisioned",
+                "description": "Application Domain is provisioned",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.app_domain.state.provisioning_failed",
+                "description": "Application Domain provisioning failed",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.app_link.state.deprovisioned",
+                "description": "Application Link is deprovisioned",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.app_link.state.deprovisioning",
+                "description": "Application Link is deprovisioning",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.app_link.state.deprovisioning_failed",
+                "description": "Application Link deprovisioning failed",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.app_link.state.provisioned",
+                "description": "Application Link is provisioned",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.app_link.state.provisioning",
+                "description": "Application Link is provisioning",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.app_link.state.provisioning_failed",
+                "description": "Application Link provisioning failed",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.app_service.state.deprovisioned",
+                "description": "Application Service is deprovisioned",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.app_service.state.provisioned",
+                "description": "Application Service is provisioned",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.app_subscription.state.deprovisioned",
+                "description": "Application Subscription is deprovisioned",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.app_subscription.state.deprovisioning",
+                "description": "Application Subscription is deprovisioning",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.app_subscription.state.deprovisioning_failed",
+                "description": "Application Subscription deprovisioning failed",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.app_subscription.state.provisioned",
+                "description": "Application Subscription is provisioned",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.app_subscription.state.provisioning",
+                "description": "Application Subscription is provisioning",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.app_subscription.state.provisioning_failed",
+                "description": "Application Subscription provisioning failed",
+                "releaseStatus": "preview"
+            },
+            {
                 "name": "equinix.fabric.asn.attribute.changed",
                 "description": "ASN changed",
                 "releaseStatus": "preview"

--- a/README.md
+++ b/README.md
@@ -95,6 +95,120 @@ The following data payloads are the supported events and formats for Equinix Net
 		<th>SLO Category</th>
 	</tr>
 	<tr>
+		<td>equinix.fabric.app_domain.state.deprovisioned</td>
+		<td>Application Domain is deprovisioned</td>
+		<td>preview</td>
+	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
+	</tr>
+	<tr>
+		<td>equinix.fabric.app_domain.state.deprovisioning_failed</td>
+		<td>Application Domain deprovisioning failed</td>
+		<td>preview</td>
+	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
+	</tr>
+	<tr>
+		<td>equinix.fabric.app_domain.state.pending_verification</td>
+		<td>Application Domain verification is pending</td>
+		<td>preview</td>
+	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
+	</tr>
+	<tr>
+		<td>equinix.fabric.app_domain.state.provisioned</td>
+		<td>Application Domain is provisioned</td>
+		<td>preview</td>
+	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
+	</tr>
+	<tr>
+		<td>equinix.fabric.app_domain.state.provisioning_failed</td>
+		<td>Application Domain provisioning failed</td>
+		<td>preview</td>
+	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
+	</tr>
+	<tr>
+		<td>equinix.fabric.app_link.state.deprovisioned</td>
+		<td>Application Link is deprovisioned</td>
+		<td>preview</td>
+	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
+	</tr>
+	<tr>
+		<td>equinix.fabric.app_link.state.deprovisioning</td>
+		<td>Application Link is deprovisioning</td>
+		<td>preview</td>
+	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
+	</tr>
+	<tr>
+		<td>equinix.fabric.app_link.state.deprovisioning_failed</td>
+		<td>Application Link deprovisioning failed</td>
+		<td>preview</td>
+	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
+	</tr>
+	<tr>
+		<td>equinix.fabric.app_link.state.provisioned</td>
+		<td>Application Link is provisioned</td>
+		<td>preview</td>
+	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
+	</tr>
+	<tr>
+		<td>equinix.fabric.app_link.state.provisioning</td>
+		<td>Application Link is provisioning</td>
+		<td>preview</td>
+	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
+	</tr>
+	<tr>
+		<td>equinix.fabric.app_link.state.provisioning_failed</td>
+		<td>Application Link provisioning failed</td>
+		<td>preview</td>
+	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
+	</tr>
+	<tr>
+		<td>equinix.fabric.app_service.state.deprovisioned</td>
+		<td>Application Service is deprovisioned</td>
+		<td>preview</td>
+	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
+	</tr>
+	<tr>
+		<td>equinix.fabric.app_service.state.provisioned</td>
+		<td>Application Service is provisioned</td>
+		<td>preview</td>
+	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
+	</tr>
+	<tr>
+		<td>equinix.fabric.app_subscription.state.deprovisioned</td>
+		<td>Application Subscription is deprovisioned</td>
+		<td>preview</td>
+	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
+	</tr>
+	<tr>
+		<td>equinix.fabric.app_subscription.state.deprovisioning</td>
+		<td>Application Subscription is deprovisioning</td>
+		<td>preview</td>
+	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
+	</tr>
+	<tr>
+		<td>equinix.fabric.app_subscription.state.deprovisioning_failed</td>
+		<td>Application Subscription deprovisioning failed</td>
+		<td>preview</td>
+	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
+	</tr>
+	<tr>
+		<td>equinix.fabric.app_subscription.state.provisioned</td>
+		<td>Application Subscription is provisioned</td>
+		<td>preview</td>
+	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
+	</tr>
+	<tr>
+		<td>equinix.fabric.app_subscription.state.provisioning</td>
+		<td>Application Subscription is provisioning</td>
+		<td>preview</td>
+	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
+	</tr>
+	<tr>
+		<td>equinix.fabric.app_subscription.state.provisioning_failed</td>
+		<td>Application Subscription provisioning failed</td>
+		<td>preview</td>
+	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
+	</tr>
+	<tr>
 		<td>equinix.fabric.asn.attribute.changed</td>
 		<td>ASN changed</td>
 		<td>preview</td>

--- a/jsonschema/catalog.json
+++ b/jsonschema/catalog.json
@@ -33,6 +33,120 @@
             "datatype": "equinix.fabric.v1.ChangeEvent",
             "cloudeventTypes": [
                 {
+                    "name": "equinix.fabric.app_domain.state.deprovisioned",
+                    "description": "Application Domain is deprovisioned",
+                    "sloCategoryCode": "BLUE_EVENT_SLO",
+                    "releaseStatus": "preview"
+                },
+                {
+                    "name": "equinix.fabric.app_domain.state.deprovisioning_failed",
+                    "description": "Application Domain deprovisioning failed",
+                    "sloCategoryCode": "BLUE_EVENT_SLO",
+                    "releaseStatus": "preview"
+                },
+                {
+                    "name": "equinix.fabric.app_domain.state.pending_verification",
+                    "description": "Application Domain verification is pending",
+                    "sloCategoryCode": "BLUE_EVENT_SLO",
+                    "releaseStatus": "preview"
+                },
+                {
+                    "name": "equinix.fabric.app_domain.state.provisioned",
+                    "description": "Application Domain is provisioned",
+                    "sloCategoryCode": "BLUE_EVENT_SLO",
+                    "releaseStatus": "preview"
+                },
+                {
+                    "name": "equinix.fabric.app_domain.state.provisioning_failed",
+                    "description": "Application Domain provisioning failed",
+                    "sloCategoryCode": "BLUE_EVENT_SLO",
+                    "releaseStatus": "preview"
+                },
+                {
+                    "name": "equinix.fabric.app_link.state.deprovisioned",
+                    "description": "Application Link is deprovisioned",
+                    "sloCategoryCode": "BLUE_EVENT_SLO",
+                    "releaseStatus": "preview"
+                },
+                {
+                    "name": "equinix.fabric.app_link.state.deprovisioning",
+                    "description": "Application Link is deprovisioning",
+                    "sloCategoryCode": "BLUE_EVENT_SLO",
+                    "releaseStatus": "preview"
+                },
+                {
+                    "name": "equinix.fabric.app_link.state.deprovisioning_failed",
+                    "description": "Application Link deprovisioning failed",
+                    "sloCategoryCode": "BLUE_EVENT_SLO",
+                    "releaseStatus": "preview"
+                },
+                {
+                    "name": "equinix.fabric.app_link.state.provisioned",
+                    "description": "Application Link is provisioned",
+                    "sloCategoryCode": "BLUE_EVENT_SLO",
+                    "releaseStatus": "preview"
+                },
+                {
+                    "name": "equinix.fabric.app_link.state.provisioning",
+                    "description": "Application Link is provisioning",
+                    "sloCategoryCode": "BLUE_EVENT_SLO",
+                    "releaseStatus": "preview"
+                },
+                {
+                    "name": "equinix.fabric.app_link.state.provisioning_failed",
+                    "description": "Application Link provisioning failed",
+                    "sloCategoryCode": "BLUE_EVENT_SLO",
+                    "releaseStatus": "preview"
+                },
+                {
+                    "name": "equinix.fabric.app_service.state.deprovisioned",
+                    "description": "Application Service is deprovisioned",
+                    "sloCategoryCode": "BLUE_EVENT_SLO",
+                    "releaseStatus": "preview"
+                },
+                {
+                    "name": "equinix.fabric.app_service.state.provisioned",
+                    "description": "Application Service is provisioned",
+                    "sloCategoryCode": "BLUE_EVENT_SLO",
+                    "releaseStatus": "preview"
+                },
+                {
+                    "name": "equinix.fabric.app_subscription.state.deprovisioned",
+                    "description": "Application Subscription is deprovisioned",
+                    "sloCategoryCode": "BLUE_EVENT_SLO",
+                    "releaseStatus": "preview"
+                },
+                {
+                    "name": "equinix.fabric.app_subscription.state.deprovisioning",
+                    "description": "Application Subscription is deprovisioning",
+                    "sloCategoryCode": "BLUE_EVENT_SLO",
+                    "releaseStatus": "preview"
+                },
+                {
+                    "name": "equinix.fabric.app_subscription.state.deprovisioning_failed",
+                    "description": "Application Subscription deprovisioning failed",
+                    "sloCategoryCode": "BLUE_EVENT_SLO",
+                    "releaseStatus": "preview"
+                },
+                {
+                    "name": "equinix.fabric.app_subscription.state.provisioned",
+                    "description": "Application Subscription is provisioned",
+                    "sloCategoryCode": "BLUE_EVENT_SLO",
+                    "releaseStatus": "preview"
+                },
+                {
+                    "name": "equinix.fabric.app_subscription.state.provisioning",
+                    "description": "Application Subscription is provisioning",
+                    "sloCategoryCode": "BLUE_EVENT_SLO",
+                    "releaseStatus": "preview"
+                },
+                {
+                    "name": "equinix.fabric.app_subscription.state.provisioning_failed",
+                    "description": "Application Subscription provisioning failed",
+                    "sloCategoryCode": "BLUE_EVENT_SLO",
+                    "releaseStatus": "preview"
+                },
+                {
                     "name": "equinix.fabric.asn.attribute.changed",
                     "description": "ASN changed",
                     "sloCategoryCode": "BLUE_EVENT_SLO",

--- a/jsonschema/equinix/fabric/v1/ChangeEvent.json
+++ b/jsonschema/equinix/fabric/v1/ChangeEvent.json
@@ -1235,6 +1235,120 @@
             "description": "Service Profile Connection ${connection_name} state changed to failed",
             "sloCategoryCode": "BLUE_EVENT_SLO",
             "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.app_subscription.state.provisioning",
+            "description": "Application Subscription is provisioning",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.app_subscription.state.provisioned",
+            "description": "Application Subscription is provisioned",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.app_subscription.state.provisioning_failed",
+            "description": "Application Subscription provisioning failed",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.app_subscription.state.deprovisioning",
+            "description": "Application Subscription is deprovisioning",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.app_subscription.state.deprovisioned",
+            "description": "Application Subscription is deprovisioned",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.app_subscription.state.deprovisioning_failed",
+            "description": "Application Subscription deprovisioning failed",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.app_domain.state.pending_verification",
+            "description": "Application Domain verification is pending",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.app_domain.state.provisioned",
+            "description": "Application Domain is provisioned",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.app_domain.state.deprovisioned",
+            "description": "Application Domain is deprovisioned",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.app_domain.state.provisioning_failed",
+            "description": "Application Domain provisioning failed",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.app_domain.state.deprovisioning_failed",
+            "description": "Application Domain deprovisioning failed",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.app_link.state.provisioning",
+            "description": "Application Link is provisioning",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.app_link.state.provisioned",
+            "description": "Application Link is provisioned",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.app_link.state.provisioning_failed",
+            "description": "Application Link provisioning failed",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.app_link.state.deprovisioning",
+            "description": "Application Link is deprovisioning",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.app_link.state.deprovisioned",
+            "description": "Application Link is deprovisioned",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.app_link.state.deprovisioning_failed",
+            "description": "Application Link deprovisioning failed",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.app_service.state.provisioned",
+            "description": "Application Service is provisioned",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
+        },
+        {
+            "name": "equinix.fabric.app_service.state.deprovisioned",
+            "description": "Application Service is deprovisioned",
+            "sloCategoryCode": "BLUE_EVENT_SLO",
+            "releaseStatus": "preview"
         }
     ],
     "metricNames": [],


### PR DESCRIPTION
Register new preview ChangeEvent types for four Fabric App Connect resource families: app_subscription, app_domain, app_link, and app_service. All 19 event types are added as preview (DEV-only) per CONTRIBUTING.md, sharing the existing fabric ChangeEvent data schema.

## Checklist
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I certify that my `preview` and `released` lists for Events/Metrics/Alerts are correct
- [x] I certify that all Events/Metrics/Alerts in `released` are properly tested and ready for production
