### PR TITLE
Adding cloud event types to support Phase 2 ESH notifications

### DIFF
--- a/DataLoader.json
+++ b/DataLoader.json
@@ -2586,31 +2586,31 @@
             {
                 "name": "equinix.network.maintenance.state.cancelled",
                 "description": "Network maintenance state changed to cancelled",
-                "releaseStatus": "preview"
+                "releaseStatus": "released"
             },
             {
                 "name": "equinix.network.maintenance.state.completed",
                 "description": "Network maintenance state changed to completed",
-                "releaseStatus": "preview"
+                "releaseStatus": "released"
             },
             {
                 "name": "equinix.network.maintenance.state.confirmed",
                 "description": "Network maintenance state changed to confirmed",
-                "releaseStatus": "preview"
+                "releaseStatus": "released"
             },
             {
                 "name": "equinix.network.maintenance.state.extended",
                 "description": "Network maintenance state changed to extended",
-                "releaseStatus": "preview"
-            },
-            {
-                "name": "equinix.network.maintenance.state.in_progress",
-                "description": "Network maintenance state changed to in_progress",
-                "releaseStatus": "preview"
+                "releaseStatus": "released"
             },
             {
                 "name": "equinix.network.maintenance.state.rescheduled",
                 "description": "Network maintenance state changed to rescheduled",
+                "releaseStatus": "released"
+            },
+            {
+                "name": "equinix.network.maintenance.state.in_progress",
+                "description": "Network maintenance state changed to in_progress",
                 "releaseStatus": "preview"
             },
             {

--- a/README.md
+++ b/README.md
@@ -1286,25 +1286,25 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.network.maintenance.state.cancelled</td>
 		<td>Network maintenance state changed to cancelled</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.network.maintenance.state.completed</td>
 		<td>Network maintenance state changed to completed</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.network.maintenance.state.confirmed</td>
 		<td>Network maintenance state changed to confirmed</td>
-		<td>preview</td>
+		<td>released</td>
 	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.network.maintenance.state.extended</td>
 		<td>Network maintenance state changed to extended</td>
-		<td>preview</td>
+		<td>released</td>
 	<td>-</td>
 	</tr>
 	<tr>
@@ -1316,7 +1316,7 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.network.maintenance.state.rescheduled</td>
 		<td>Network maintenance state changed to rescheduled</td>
-		<td>preview</td>
+		<td>released</td>
 	<td>-</td>
 	</tr>
 	<tr>

--- a/jsonschema/catalog.json
+++ b/jsonschema/catalog.json
@@ -1217,24 +1217,24 @@
                     "name": "equinix.network.maintenance.state.cancelled",
                     "description": "Network maintenance state changed to cancelled",
                     "sloCategoryCode": "BLUE_EVENT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.network.maintenance.state.completed",
                     "description": "Network maintenance state changed to completed",
                     "sloCategoryCode": "BLUE_EVENT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.network.maintenance.state.confirmed",
                     "description": "Network maintenance state changed to confirmed",
                     "sloCategoryCode": "BLUE_EVENT_SLO",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.network.maintenance.state.extended",
                     "description": "Network maintenance state changed to extended",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.network.maintenance.state.in_progress",
@@ -1245,7 +1245,7 @@
                 {
                     "name": "equinix.network.maintenance.state.rescheduled",
                     "description": "Network maintenance state changed to rescheduled",
-                    "releaseStatus": "preview"
+                    "releaseStatus": "released"
                 },
                 {
                     "name": "equinix.network.repair.state.completed",

--- a/jsonschema/equinix/network/v1/NotificationEvent.json
+++ b/jsonschema/equinix/network/v1/NotificationEvent.json
@@ -127,7 +127,7 @@
       "name": "equinix.network.maintenance.state.confirmed",
       "description": "Network maintenance state changed to confirmed",
       "sloCategoryCode": "BLUE_EVENT_SLO",
-      "releaseStatus": "preview"
+      "releaseStatus": "released"
     },
     {
       "name": "equinix.network.maintenance.state.in_progress",
@@ -139,23 +139,23 @@
       "name": "equinix.network.maintenance.state.cancelled",
       "description": "Network maintenance state changed to cancelled",
       "sloCategoryCode": "BLUE_EVENT_SLO",
-      "releaseStatus": "preview"
+      "releaseStatus": "released"
     },
     {
       "name": "equinix.network.maintenance.state.completed",
       "description": "Network maintenance state changed to completed",
       "sloCategoryCode": "BLUE_EVENT_SLO",
-      "releaseStatus": "preview"
+      "releaseStatus": "released"
     },
     {
       "name": "equinix.network.maintenance.state.extended",
       "description": "Network maintenance state changed to extended",
-      "releaseStatus": "preview"
+      "releaseStatus": "released"
     },
     {
       "name": "equinix.network.maintenance.state.rescheduled",
       "description": "Network maintenance state changed to rescheduled",
-      "releaseStatus": "preview"
+      "releaseStatus": "released"
     },
     {
       "name": "equinix.network.repair.state.completed",


### PR DESCRIPTION
## Checklist
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I certify that my `preview` and `released` lists for Events/Metrics/Alerts are correct
- [x] I certify that all Events/Metrics/Alerts in `released` are properly tested and ready for production
