### PR TITLE
moving original service profile event types back to preview status

### DIFF
--- a/DataLoader.json
+++ b/DataLoader.json
@@ -703,26 +703,6 @@
                 "releaseStatus": "released"
             },
             {
-                "name": "equinix.fabric.service_profile.connection.deprovisioned",
-                "description": "Service Profile Connection ${connection_name} state changed to deprovisioned",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.service_profile.connection.failed",
-                "description": "Service Profile Connection ${connection_name} state changed to failed",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.service_profile.connection.pending",
-                "description": "Service Profile Connection ${connection_name} state changed to pending",
-                "releaseStatus": "released"
-            },
-            {
-                "name": "equinix.fabric.service_profile.connection.provisioned",
-                "description": "Service Profile Connection ${connection_name} state changed to provisioned",
-                "releaseStatus": "released"
-            },
-            {
                 "name": "equinix.fabric.service_profile_connection.state.deprovisioned",
                 "description": "Service Profile Connection ${connection_name} state changed to deprovisioned",
                 "releaseStatus": "released"
@@ -970,6 +950,26 @@
             {
                 "name": "equinix.fabric.route_filter_rule.attribute.changed",
                 "description": "Route Filter Rule named ${route_filter_rule_name} attribute changed",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.service_profile.connection.deprovisioned",
+                "description": "Service Profile Connection ${connection_name} state changed to deprovisioned",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.service_profile.connection.failed",
+                "description": "Service Profile Connection ${connection_name} state changed to failed",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.service_profile.connection.pending",
+                "description": "Service Profile Connection ${connection_name} state changed to pending",
+                "releaseStatus": "preview"
+            },
+            {
+                "name": "equinix.fabric.service_profile.connection.provisioned",
+                "description": "Service Profile Connection ${connection_name} state changed to provisioned",
                 "releaseStatus": "preview"
             },
             {

--- a/README.md
+++ b/README.md
@@ -1117,25 +1117,25 @@ The following data payloads are the supported events and formats for Equinix Net
 	<tr>
 		<td>equinix.fabric.service_profile.connection.deprovisioned</td>
 		<td>Service Profile Connection ${connection_name} state changed to deprovisioned</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.service_profile.connection.failed</td>
 		<td>Service Profile Connection ${connection_name} state changed to failed</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.service_profile.connection.pending</td>
 		<td>Service Profile Connection ${connection_name} state changed to pending</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
 	</tr>
 	<tr>
 		<td>equinix.fabric.service_profile.connection.provisioned</td>
 		<td>Service Profile Connection ${connection_name} state changed to provisioned</td>
-		<td>released</td>
+		<td>preview</td>
 	<td><a href='#blue_event_slo'> <span style='color:blue'>BLUE_EVENT_SLO</span></a></td>
 	</tr>
 	<tr>

--- a/jsonschema/catalog.json
+++ b/jsonschema/catalog.json
@@ -1056,25 +1056,25 @@
                     "name": "equinix.fabric.service_profile.connection.deprovisioned",
                     "description": "Service Profile Connection ${connection_name} state changed to deprovisioned",
                     "sloCategoryCode": "BLUE_EVENT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.service_profile.connection.failed",
                     "description": "Service Profile Connection ${connection_name} state changed to failed",
                     "sloCategoryCode": "BLUE_EVENT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.service_profile.connection.pending",
                     "description": "Service Profile Connection ${connection_name} state changed to pending",
                     "sloCategoryCode": "BLUE_EVENT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.service_profile.connection.provisioned",
                     "description": "Service Profile Connection ${connection_name} state changed to provisioned",
                     "sloCategoryCode": "BLUE_EVENT_SLO",
-                    "releaseStatus": "released"
+                    "releaseStatus": "preview"
                 },
                 {
                     "name": "equinix.fabric.service_profile_connection.state.deprovisioned",

--- a/jsonschema/equinix/fabric/v1/ChangeEvent.json
+++ b/jsonschema/equinix/fabric/v1/ChangeEvent.json
@@ -1216,7 +1216,7 @@
             "name": "equinix.fabric.service_profile.connection.pending",
             "description": "Service Profile Connection ${connection_name} state changed to pending",
             "sloCategoryCode": "BLUE_EVENT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.service_profile_connection.state.pending",
@@ -1228,7 +1228,7 @@
             "name": "equinix.fabric.service_profile.connection.provisioned",
             "description": "Service Profile Connection ${connection_name} state changed to provisioned",
             "sloCategoryCode": "BLUE_EVENT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.service_profile_connection.state.provisioned",
@@ -1240,7 +1240,7 @@
             "name": "equinix.fabric.service_profile.connection.deprovisioned",
             "description": "Service Profile Connection ${connection_name} state changed to deprovisioned",
             "sloCategoryCode": "BLUE_EVENT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.service_profile_connection.state.deprovisioned",
@@ -1252,7 +1252,7 @@
             "name": "equinix.fabric.service_profile.connection.failed",
             "description": "Service Profile Connection ${connection_name} state changed to failed",
             "sloCategoryCode": "BLUE_EVENT_SLO",
-            "releaseStatus": "released"
+            "releaseStatus": "preview"
         },
         {
             "name": "equinix.fabric.service_profile_connection.state.failed",


### PR DESCRIPTION
## Checklist
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I certify that my `preview` and `released` lists for Events/Metrics/Alerts are correct
- [x] I certify that all Events/Metrics/Alerts in `released` are properly tested and ready for production
